### PR TITLE
Shorten panel frames and align full-art cards

### DIFF
--- a/embedded-art.js
+++ b/embedded-art.js
@@ -1,0 +1,30 @@
+/* Remote featured card artwork mapping. */
+(function (global) {
+  const remoteArtEntries = [
+    [
+      "ancient-treant",
+      "https://github.com/flezz60-creator/test/blob/bbe64f2576318157c1bcb844ccd33d0cc62274ac/ancient%20treant.jpg?raw=1",
+    ],
+    [
+      "avatar-of-the-grove",
+      "https://github.com/flezz60-creator/test/blob/befd0c7ef08e4bbbd4d534d70d8a3aff42503b81/avatar%20of%20the%20grove.jpg?raw=1",
+    ],
+    [
+      "druid-of-the-grove",
+      "https://github.com/flezz60-creator/test/blob/befd0c7ef08e4bbbd4d534d70d8a3aff42503b81/druid%20of%20the%20grove.jpg?raw=1",
+    ],
+    [
+      "elder-dryad",
+      "https://github.com/flezz60-creator/test/blob/befd0c7ef08e4bbbd4d534d70d8a3aff42503b81/elder%20dryad.jpg?raw=1",
+    ],
+    [
+      "forest-guardian",
+      "https://github.com/flezz60-creator/test/blob/befd0c7ef08e4bbbd4d534d70d8a3aff42503b81/forest%20guardian.png?raw=1",
+    ],
+  ];
+
+  const artMap = new Map(remoteArtEntries);
+  if (global && typeof global === "object") {
+    global.embeddedCardArt = artMap;
+  }
+})(typeof window !== "undefined" ? window : (typeof globalThis !== "undefined" ? globalThis : {}));

--- a/index.html
+++ b/index.html
@@ -1,0 +1,452 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Collection Fever – Rare Hunt</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Space+Grotesk:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <script defer src="embedded-art.js"></script>
+    <script defer src="main.js"></script>
+  </head>
+  <body>
+    <header class="hero">
+      <div class="hero-content">
+        <p class="label">Pixelverse Studio präsentiert</p>
+        <h1>Collection Fever – Rare Hunt</h1>
+        <p class="lede">
+          Ein atmosphärisches Indie-Sammelabenteuer. Öffne Booster, jage nach
+          ultra-seltenen Artefakten und fühle den Nervenkitzel jedes Fundes.
+        </p>
+        <div class="hero-actions">
+          <button id="cta-open-pack" class="primary">Jetzt Booster öffnen</button>
+          <button id="cta-explore" class="ghost">Deck planen</button>
+        </div>
+        <div class="meta">
+          <div>
+            <span class="meta-label">Seltenste Karte</span>
+            <span class="meta-value" id="legendary-highlight">–</span>
+          </div>
+          <div>
+            <span class="meta-label">Aktive Sets</span>
+            <span class="meta-value" id="active-set-count">0</span>
+          </div>
+          <div>
+            <span class="meta-label">Login-Streak</span>
+            <span class="meta-value" id="hero-streak">0</span>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <nav class="top-bar panel-nav" aria-label="Bereiche">
+        <span class="badge">Indie Prototype</span>
+        <ul class="nav-links">
+          <li><a href="#loop" data-panel-target="loop">Retention-Loop</a></li>
+          <li><a href="#daily" data-panel-target="daily">Daily Bonus</a></li>
+          <li><a href="#pack-lab" data-panel-target="pack-lab">Pack-Labor</a></li>
+          <li><a href="#collection" data-panel-target="collection">Sammlung</a></li>
+          <li><a href="#deckbuilder" data-panel-target="deckbuilder">Deck-Werkstatt</a></li>
+          <li><a href="#multiplayer" data-panel-target="multiplayer">Arena</a></li>
+        </ul>
+      </nav>
+      <div class="panel-viewport" id="panel-viewport">
+        <div class="panel-track" id="panel-track">
+      <section id="loop" class="panel loop">
+        <h2>Retention-Loop</h2>
+        <div class="loop-grid">
+          <article>
+            <h3>Trigger</h3>
+            <p>
+              Limitierte Events und tägliche Login-Reminders holen dich in die
+              Welt zurück – verpasse keine rare Chance!
+            </p>
+          </article>
+          <article>
+            <h3>Action</h3>
+            <p>
+              Drehe das Schicksalsrad, meistere Mini-Quests und öffne Booster.
+              Jede Entscheidung erhöht die Spannung.
+            </p>
+          </article>
+          <article>
+            <h3>Reward</h3>
+            <p>
+              Variable Drops mit opulenten Reveal-Animationen liefern den
+              Indie-typischen Dopamin-Kick.
+            </p>
+          </article>
+          <article>
+            <h3>Investment</h3>
+            <p>
+              Sortiere deine Alben, handle doppelte Karten und vervollständige
+              legendäre Sets für Ruhm auf dem Leaderboard.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section id="daily" class="panel daily">
+        <div class="panel-header">
+          <h2>Daily Login Ritual</h2>
+          <p>
+            Halte deinen Streak am Leben, kassiere wachsende Belohnungen und
+            unlocke spezielle Event-Tickets.
+          </p>
+        </div>
+        <div class="daily-grid">
+          <div class="login-card">
+            <div class="streak">
+              <span>Streak</span>
+              <strong id="daily-streak">0</strong>
+            </div>
+            <button id="claim-login" class="primary">Belohnung abholen</button>
+            <p class="login-status" id="login-status">Bereit für deinen Bonus!</p>
+            <div class="next-reward">
+              <span>Nächster Meilenstein</span>
+              <p id="next-milestone">Tag 7: Garantierte epische Karte</p>
+            </div>
+          </div>
+          <div class="reward-preview">
+            <h3>Heutige Belohnung</h3>
+            <div class="reward-display" id="daily-reward-display">
+              <p>Hole dir den Bonus, um deine Überraschung zu enthüllen.</p>
+            </div>
+            <small>
+              Tipp: Schließe wöchentliche Quests, um zusätzliche Login-Siegel
+              für das Event zu verdienen.
+            </small>
+          </div>
+        </div>
+      </section>
+
+      <section id="pack-lab" class="panel packs">
+        <div class="panel-header">
+          <h2>Booster-Labor</h2>
+          <p>
+            Wähle dein Set, öffne ein Pack und erlebe die Spannung dynamischer
+            Drop-Rates.
+          </p>
+        </div>
+        <div class="pack-controls">
+          <label for="pack-select">Set-Auswahl</label>
+          <select id="pack-select" aria-label="Booster wählen"></select>
+          <button id="open-pack" class="primary">Pack öffnen</button>
+        </div>
+        <div class="pack-results" id="pack-results">
+          <p class="placeholder">Noch keine Karten – öffne dein erstes Pack!</p>
+        </div>
+      </section>
+
+      <section id="collection" class="panel collection">
+        <div class="panel-header">
+          <h2>Sammlungs-Atlas</h2>
+          <p>
+            Behalte deine Fortschritte im Blick, vervollständige Sets und
+            sichere dir mystische Boni.
+          </p>
+        </div>
+        <div class="collection-stats">
+          <div>
+            <span class="stat-label">Gesammelte Karten</span>
+            <strong id="total-owned">0</strong>
+          </div>
+          <div>
+            <span class="stat-label">Einzigartige Karten</span>
+            <strong id="unique-owned">0</strong>
+          </div>
+          <div>
+            <span class="stat-label">Vervollständigte Sets</span>
+            <strong id="completed-sets">0</strong>
+          </div>
+        </div>
+        <div class="set-progress-grid" id="collection-grid"></div>
+        <div class="trade-hub" id="trade-hub">
+          <h3>Tauschbörse</h3>
+          <p>
+            Teile deine Duplikate mit Freunden oder suche nach der letzten Karte
+            für dein Lieblings-Set.
+          </p>
+          <ul id="trade-list"></ul>
+        </div>
+        <div class="collection-viewer">
+          <h3>Sammlungs-Archiv</h3>
+          <div class="collection-toolbar" role="group" aria-label="Filter für die Sammlung">
+            <div class="collection-field collection-field--search">
+              <label for="collection-search">Suche</label>
+              <input
+                id="collection-search"
+                class="collection-input"
+                type="search"
+                name="collection-search"
+                placeholder="Kartennamen oder Effekte"
+                autocomplete="off"
+                spellcheck="false"
+              />
+            </div>
+            <div class="collection-field">
+              <label for="collection-filter-set">Set</label>
+              <select id="collection-filter-set" class="collection-input" name="collection-filter-set"></select>
+            </div>
+            <div class="collection-field">
+              <label for="collection-filter-rarity">Seltenheit</label>
+              <select
+                id="collection-filter-rarity"
+                class="collection-input"
+                name="collection-filter-rarity"
+              ></select>
+            </div>
+            <div class="collection-field">
+              <label for="collection-sort">Sortieren</label>
+              <select id="collection-sort" class="collection-input" name="collection-sort"></select>
+            </div>
+            <label class="collection-toggle">
+              <input id="collection-owned-toggle" type="checkbox" name="collection-owned-toggle" checked />
+              <span>Nur Besitz</span>
+            </label>
+            <label class="collection-toggle">
+              <input
+                id="collection-duplicates-toggle"
+                type="checkbox"
+                name="collection-duplicates-toggle"
+              />
+              <span>Nur Duplikate</span>
+            </label>
+          </div>
+          <p id="collection-filter-summary" class="collection-filter-summary"></p>
+          <div id="collection-card-grid" class="collection-card-grid" aria-live="polite"></div>
+          <p id="collection-empty" class="collection-empty" hidden>
+            Noch keine Karten – öffne Booster oder sichere dir den Daily Bonus.
+          </p>
+        </div>
+      </section>
+
+      <section id="deckbuilder" class="panel deckbuilder">
+        <div class="panel-header">
+          <h2>Deck-Werkstatt</h2>
+          <p>
+            Stelle dein Arena-Deck aus deiner Sammlung zusammen, gib ihm einen Namen und
+            speichere es für die Multiplayer-Gefechte.
+          </p>
+        </div>
+        <div class="deckbuilder-layout">
+          <aside class="deckbuilder-sidebar">
+            <h3>Aktives Arena-Deck</h3>
+            <p id="deckbuilder-status" class="deckbuilder-status" aria-live="polite"></p>
+            <label class="deckbuilder-label" for="deckbuilder-name">Deckname</label>
+            <input
+              id="deckbuilder-name"
+              class="deckbuilder-input"
+              type="text"
+              name="deckbuilder-name"
+              maxlength="40"
+              autocomplete="off"
+              spellcheck="false"
+              placeholder="z. B. Wildwood Pulse"
+            />
+            <div class="deckbuilder-actions">
+              <button id="deckbuilder-save" type="button" class="primary">Deck speichern</button>
+              <button id="deckbuilder-reset" type="button" class="ghost">Zurücksetzen</button>
+            </div>
+            <p id="deckbuilder-count" class="deckbuilder-count">0 / 30 Karten</p>
+          </aside>
+          <div class="deckbuilder-columns">
+            <div class="deckbuilder-column">
+              <header>
+                <h3>Sammlung</h3>
+                <p>
+                  Jede Karte kann nur so oft ins Deck aufgenommen werden, wie du Kopien in deiner Sammlung hast.
+                </p>
+              </header>
+              <ul id="deckbuilder-card-pool" class="deckbuilder-card-list"></ul>
+            </div>
+            <div class="deckbuilder-column">
+              <header>
+                <h3>Deckliste</h3>
+                <p>Feile an deiner Strategie, bis du die vollen 30 Karten erreicht hast.</p>
+              </header>
+              <ul id="deckbuilder-selection" class="deckbuilder-card-list"></ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="events" class="panel events">
+        <div class="event-card">
+          <h2>Event: Ember Solstice</h2>
+          <p>
+            Wärme und Funken erfüllen die Welt! Sammle limitierte Holos, nur für
+            kurze Zeit erhältlich.
+          </p>
+          <div class="event-details">
+            <div>
+              <span class="stat-label">Countdown</span>
+              <strong id="event-countdown">–</strong>
+            </div>
+            <div>
+              <span class="stat-label">Limitierte Karte</span>
+              <strong id="event-item">–</strong>
+            </div>
+            <div>
+              <span class="stat-label">Bonus</span>
+              <strong>2× Drop-Chance auf Legendäre</strong>
+            </div>
+          </div>
+          <button class="ghost" id="event-pack-btn">Event-Pack öffnen</button>
+        </div>
+      </section>
+
+      <section id="multiplayer" class="panel multiplayer">
+        <div class="panel-header">
+          <h2>Multiplayer-Arena</h2>
+          <p>
+            Tritt gegen andere Sammler an, kanalisiere Lebensessenz-Kristalle und
+            setze deine Karten taktisch ein. Jeder Zug bringt eine neue Karte und
+            einen zusätzlichen Kristall – maximal zehn wie im Hearthstone-Prinzip.
+          </p>
+        </div>
+        <div class="arena-grid">
+          <aside class="duel-overview">
+            <div class="duel-meta">
+              <div>
+                <span class="stat-label">Runde</span>
+                <strong id="duel-round">–</strong>
+              </div>
+              <div>
+                <span class="stat-label">Aktiver Spieler</span>
+                <strong id="duel-active">–</strong>
+              </div>
+            </div>
+            <div class="duel-controls">
+              <button id="duel-start" class="primary">Match starten</button>
+              <button id="duel-end-turn" class="ghost" disabled>Zug beenden</button>
+            </div>
+            <p class="duel-hint">
+              Nach jedem Zug ziehst du eine Karte, erhältst einen Kristall mehr
+              und setzt deine Sammlung direkt auf dem Feld ein. Karten bleiben
+              liegen, Bollwerke blocken Angriffe auf den Helden und wer ohne
+              Karten und Verbündete dasteht, verliert.
+            </p>
+            <details class="duel-decklist" data-duel-decklist-root>
+              <summary>Deckzusammenstellung</summary>
+              <div class="duel-decklist-body" data-duel-decklist>
+                <p class="duel-decklist-empty">
+                  Starte ein Match, um deine Deckliste zu sehen.
+                </p>
+              </div>
+            </details>
+          </aside>
+          <div class="duel-boards">
+            <div class="duel-player" data-duel-player="0">
+              <header class="duel-player-header">
+                <span class="duel-player-name">Sammler Nova</span>
+                <span class="duel-player-status">Bereit</span>
+              </header>
+              <button class="duel-hero" type="button" data-duel-hero="0" aria-label="Held von Sammler Nova">
+                <span class="duel-hero-label">Held</span>
+                <span class="duel-hero-health">
+                  <strong class="duel-health-value">30</strong>
+                  <small>LP</small>
+                </span>
+              </button>
+              <div class="duel-player-stats">
+                <div>
+                  <span class="stat-label">Deck</span>
+                  <strong class="duel-deck-count">0</strong>
+                </div>
+                <div>
+                  <span class="stat-label">Hand</span>
+                  <strong class="duel-hand-count">0</strong>
+                </div>
+                <div>
+                  <span class="stat-label">Feld</span>
+                  <strong class="duel-board-count">0</strong>
+                </div>
+              </div>
+              <div class="duel-crystals" aria-label="Lebensessenz-Kristalle"></div>
+              <div class="duel-board" data-duel-board="0" role="list" aria-label="Spielfeld"></div>
+              <div class="duel-hand" data-duel-hand="0" role="list" aria-label="Handkarten">
+                <p class="duel-hand-empty">Starte die Arena, um Karten zu ziehen.</p>
+              </div>
+            </div>
+            <div class="duel-player" data-duel-player="1">
+              <header class="duel-player-header">
+                <span class="duel-player-name">Archivjäger Vega</span>
+                <span class="duel-player-status">Bereit</span>
+              </header>
+              <button class="duel-hero" type="button" data-duel-hero="1" aria-label="Held von Archivjäger Vega">
+                <span class="duel-hero-label">Held</span>
+                <span class="duel-hero-health">
+                  <strong class="duel-health-value">30</strong>
+                  <small>LP</small>
+                </span>
+              </button>
+              <div class="duel-player-stats">
+                <div>
+                  <span class="stat-label">Deck</span>
+                  <strong class="duel-deck-count">0</strong>
+                </div>
+                <div>
+                  <span class="stat-label">Hand</span>
+                  <strong class="duel-hand-count">0</strong>
+                </div>
+                <div>
+                  <span class="stat-label">Feld</span>
+                  <strong class="duel-board-count">0</strong>
+                </div>
+              </div>
+              <div class="duel-crystals" aria-label="Lebensessenz-Kristalle"></div>
+              <div class="duel-board" data-duel-board="1" role="list" aria-label="Spielfeld"></div>
+              <div class="duel-hand" data-duel-hand="1" role="list" aria-label="Handkarten">
+                <p class="duel-hand-empty">Starte die Arena, um Karten zu ziehen.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="duel-target-panel" id="duel-target-panel">
+          <p class="duel-target-message" id="duel-target-message" aria-live="polite">
+            Wähle eine Karte deiner Seite, um einen Angriff oder Zauber zu beginnen.
+          </p>
+          <div class="duel-target-list" id="duel-target-list" role="list"></div>
+          <button type="button" class="duel-target-cancel" id="duel-target-cancel">
+            Auswahl aufheben
+          </button>
+        </div>
+        <div class="duel-log-wrapper">
+          <h3>Gefechtslog</h3>
+          <ol class="duel-log" id="duel-log" aria-live="polite"></ol>
+        </div>
+      </section>
+
+      <section id="roadmap" class="panel roadmap">
+        <h2>Ausblick</h2>
+        <div class="roadmap-grid">
+          <article>
+            <h3>Crafting-Werkstatt</h3>
+            <p>Schmelze Commons zu Rare-Scherben und forme eigene Artefakte.</p>
+          </article>
+          <article>
+            <h3>Co-op Expedition</h3>
+            <p>Schließe dich in Teams zusammen und erobere zeitbegrenzte Dungeons.</p>
+          </article>
+          <article>
+            <h3>Arcade Duelle</h3>
+            <p>Setze deine Lieblingskarten in schnellen Indie-PvP-Matches ein.</p>
+          </article>
+        </div>
+      </section>
+        </div>
+      </div>
+    </main>
+
+    <footer class="footer">
+      <p>© 2024 Collection Fever – Rare Hunt. Ein liebevoller Indie-Prototyp.</p>
+    </footer>
+  </body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,5302 @@
+(() => {
+  const rarityLabels = {
+    common: "Common",
+    uncommon: "Uncommon",
+    rare: "Rare",
+    epic: "Epic",
+    legendary: "Legendary",
+  };
+
+  const rarityScore = {
+    common: 0,
+    uncommon: 1,
+    rare: 2,
+    epic: 3,
+    legendary: 4,
+  };
+
+  function estimateCardCost(item) {
+    const rarityWeight = (rarityScore[item.rarity] ?? 0) * 0.9;
+
+    if (item.cardType === "spell") {
+      const effect = item.effect ?? {};
+      const amount = effect.amount ?? item.damage ?? 0;
+      let potency = 0;
+      switch (effect.type) {
+        case "directDamage":
+          potency = amount * 0.85;
+          break;
+        case "enemyUnitDamage":
+          potency = amount * 0.75 + 0.4;
+          break;
+        case "damageAllEnemies":
+          potency = amount * 1.25 + 1.2;
+          break;
+        case "healHero":
+          potency = amount * 0.55;
+          break;
+        case "allyHeal":
+          potency = amount * 0.65;
+          break;
+        case "grantBarrier":
+          potency = amount * 0.6 + 0.5;
+          break;
+        case "summonUnits": {
+          const summonCount = Math.max(1, effect.count ?? 1);
+          potency = summonCount * 1.5 + 0.8;
+          break;
+        }
+        case "healAllies":
+          potency = amount * 0.7 + 0.6;
+          break;
+        case "buffAlliesAttack":
+          potency = amount * 1.1 + 0.7;
+          break;
+        case "grantExtraAttack":
+          potency = 1.6;
+          break;
+        case "stun":
+          potency = 1.4 + (effect.duration ?? 1) * 0.4;
+          break;
+        case "drawCards": {
+          const drawAmount = effect.amount ?? amount ?? 0;
+          potency = drawAmount * 1.2 + 0.5;
+          break;
+        }
+        case "healAndFortifyAllies": {
+          const heal = effect.heal ?? amount ?? 0;
+          const barrier = effect.barrier ?? 0;
+          potency = heal * 0.65 + barrier * 0.8 + 0.9;
+          break;
+        }
+        default:
+          potency = item.damage * 0.8 + item.health * 0.4;
+          break;
+      }
+      return potency + rarityWeight + 0.7;
+    }
+
+    const offense = item.damage * 1.25;
+    const defense = item.health * 0.9;
+    const abilityBonus = Array.isArray(item.abilities) && item.abilities.includes("bulwark") ? 1.4 : 0;
+    return (offense + defense) / 2.15 + rarityWeight + 0.6 + abilityBonus;
+  }
+
+  const sets = [
+    {
+      id: "celestial",
+      name: "Celestial Archives",
+      description: "Die 13 Götterkarten, die das Firmament beschützen.",
+      total: 13,
+    },
+    {
+      id: "clockwork",
+      name: "Clockwork Depths",
+      description: "Unterwasser-Maschinen und vergessene Automata.",
+      total: 10,
+    },
+    {
+      id: "wildwood",
+      name: "Wildwood Spirits",
+      description: "Wilde Naturgeister aus einem neonfarbenen Wald.",
+      total: 30,
+    },
+  ];
+
+  const allItems = [
+    // Celestial Archives
+    { id: "aurora-scribe", name: "Aurora Scribe", rarity: "common", setId: "celestial", damage: 2, health: 3 },
+    { id: "lumen-oracle", name: "Lumen Oracle", rarity: "common", setId: "celestial", damage: 1, health: 4 },
+    { id: "starlit-vanguard", name: "Starlit Vanguard", rarity: "common", setId: "celestial", damage: 3, health: 4 },
+    { id: "echo-wanderer", name: "Echo Wanderer", rarity: "common", setId: "celestial", damage: 2, health: 2 },
+    { id: "astral-herald", name: "Astral Herald", rarity: "common", setId: "celestial", damage: 3, health: 3 },
+    { id: "nebula-mender", name: "Nebula Mender", rarity: "uncommon", setId: "celestial", damage: 2, health: 5 },
+    { id: "rift-cartographer", name: "Rift Cartographer", rarity: "uncommon", setId: "celestial", damage: 3, health: 5 },
+    { id: "sunscale-sentinel", name: "Sunscale Sentinel", rarity: "uncommon", setId: "celestial", damage: 4, health: 5 },
+    { id: "nova-chronicler", name: "Nova Chronicler", rarity: "rare", setId: "celestial", damage: 4, health: 6 },
+    { id: "zenith-guardian", name: "Zenith Guardian", rarity: "rare", setId: "celestial", damage: 5, health: 7 },
+    { id: "moonweaver-seraph", name: "Moonweaver Seraph", rarity: "epic", setId: "celestial", damage: 6, health: 8 },
+    { id: "aether-crown", name: "Aether Crown", rarity: "legendary", setId: "celestial", damage: 4, health: 9 },
+    {
+      id: "ember-solstice-phoenix",
+      name: "Ember Solstice Phoenix",
+      rarity: "legendary",
+      setId: "celestial",
+      isLimited: true,
+      damage: 8,
+      health: 8,
+    },
+    // Clockwork Depths
+    { id: "cogwhisper-sprite", name: "Cogwhisper Sprite", rarity: "common", setId: "clockwork", damage: 1, health: 3 },
+    { id: "emberplated-scout", name: "Emberplated Scout", rarity: "common", setId: "clockwork", damage: 3, health: 3 },
+    { id: "copper-harvester", name: "Copper Harvester", rarity: "common", setId: "clockwork", damage: 3, health: 4 },
+    { id: "gearworn-scribe", name: "Gearworn Scribe", rarity: "common", setId: "clockwork", damage: 2, health: 3 },
+    { id: "chronomancer-apprentice", name: "Chronomancer Apprentice", rarity: "uncommon", setId: "clockwork", damage: 3, health: 4 },
+    { id: "steamwright-mediator", name: "Steamwright Mediator", rarity: "uncommon", setId: "clockwork", damage: 2, health: 5 },
+    { id: "gilded-engine", name: "Gilded Engine", rarity: "rare", setId: "clockwork", damage: 4, health: 6 },
+    { id: "void-chimes", name: "Void Chimes", rarity: "rare", setId: "clockwork", damage: 3, health: 7 },
+    { id: "apex-colossus", name: "Apex Colossus", rarity: "epic", setId: "clockwork", damage: 7, health: 8 },
+    { id: "heart-of-mechanis", name: "Heart of Mechanis", rarity: "legendary", setId: "clockwork", damage: 5, health: 10 },
+    // Wildwood Spirits
+    {
+      id: "ancient-treant",
+      name: "Ancient Treant",
+      rarity: "legendary",
+      setId: "wildwood",
+      damage: 6,
+      health: 10,
+      baseCost: 10,
+    },
+    {
+      id: "avatar-of-the-grove",
+      name: "Avatar of the Grove",
+      rarity: "legendary",
+      setId: "wildwood",
+      damage: 7,
+      health: 9,
+      baseCost: 9,
+    },
+    {
+      id: "elder-dryad",
+      name: "Elder Dryad",
+      rarity: "legendary",
+      setId: "wildwood",
+      damage: 6,
+      health: 8,
+      baseCost: 8,
+    },
+    {
+      id: "forest-guardian",
+      name: "Forest Guardian",
+      rarity: "epic",
+      setId: "wildwood",
+      damage: 4,
+      health: 8,
+      baseCost: 6,
+    },
+    {
+      id: "druid-of-the-grove",
+      name: "Druid of the Grove",
+      rarity: "epic",
+      setId: "wildwood",
+      damage: 4,
+      health: 5,
+      baseCost: 6,
+    },
+    {
+      id: "sylvan-huntress",
+      name: "Sylvan Huntress",
+      rarity: "epic",
+      setId: "wildwood",
+      damage: 5,
+      health: 4,
+      baseCost: 5,
+    },
+    {
+      id: "spirit-of-renewal",
+      name: "Spirit of Renewal",
+      rarity: "epic",
+      setId: "wildwood",
+      damage: 3,
+      health: 5,
+      baseCost: 5,
+    },
+    {
+      id: "oakheart-sentinel",
+      name: "Oakheart Sentinel",
+      rarity: "rare",
+      setId: "wildwood",
+      damage: 3,
+      health: 6,
+      baseCost: 4,
+    },
+    {
+      id: "wolfkin-alpha",
+      name: "Wolfkin Alpha",
+      rarity: "rare",
+      setId: "wildwood",
+      damage: 4,
+      health: 3,
+      baseCost: 4,
+    },
+    {
+      id: "vinewhisper-druid",
+      name: "Vinewhisper Druid",
+      rarity: "rare",
+      setId: "wildwood",
+      damage: 2,
+      health: 4,
+      baseCost: 3,
+    },
+    {
+      id: "natures-fury",
+      name: "Nature’s Fury",
+      rarity: "rare",
+      setId: "wildwood",
+      damage: 0,
+      health: 0,
+      baseCost: 3,
+    },
+    {
+      id: "blessing-of-roots",
+      name: "Blessing of Roots",
+      rarity: "rare",
+      setId: "wildwood",
+      damage: 0,
+      health: 0,
+      baseCost: 2,
+    },
+    {
+      id: "call-of-the-wild",
+      name: "Call of the Wild",
+      rarity: "rare",
+      setId: "wildwood",
+      damage: 0,
+      health: 0,
+      baseCost: 5,
+    },
+    {
+      id: "ancient-ritual",
+      name: "Ancient Ritual",
+      rarity: "rare",
+      setId: "wildwood",
+      damage: 0,
+      health: 0,
+      baseCost: 4,
+    },
+    {
+      id: "woodland-archer",
+      name: "Woodland Archer",
+      rarity: "common",
+      setId: "wildwood",
+      damage: 2,
+      health: 2,
+      baseCost: 2,
+    },
+    {
+      id: "spriggan-scout",
+      name: "Spriggan Scout",
+      rarity: "common",
+      setId: "wildwood",
+      damage: 1,
+      health: 1,
+      baseCost: 1,
+    },
+    {
+      id: "thorned-beast",
+      name: "Thorned Beast",
+      rarity: "common",
+      setId: "wildwood",
+      damage: 3,
+      health: 3,
+      baseCost: 3,
+    },
+    {
+      id: "healing-stream",
+      name: "Healing Stream",
+      rarity: "common",
+      setId: "wildwood",
+      damage: 0,
+      health: 0,
+      baseCost: 2,
+    },
+    {
+      id: "forest-blessing",
+      name: "Forest Blessing",
+      rarity: "common",
+      setId: "wildwood",
+      damage: 0,
+      health: 0,
+      baseCost: 2,
+    },
+    {
+      id: "barkskin",
+      name: "Barkskin",
+      rarity: "common",
+      setId: "wildwood",
+      damage: 0,
+      health: 0,
+      baseCost: 1,
+    },
+    {
+      id: "woodland-sprite",
+      name: "Woodland Sprite",
+      rarity: "common",
+      setId: "wildwood",
+      damage: 1,
+      health: 3,
+      baseCost: 2,
+    },
+    {
+      id: "wolf-spirit",
+      name: "Wolf Spirit",
+      rarity: "common",
+      setId: "wildwood",
+      damage: 2,
+      health: 2,
+      baseCost: 2,
+    },
+    {
+      id: "treant-sapling",
+      name: "Treant Sapling",
+      rarity: "common",
+      setId: "wildwood",
+      damage: 2,
+      health: 4,
+      baseCost: 3,
+    },
+    {
+      id: "sylvan-strike",
+      name: "Sylvan Strike",
+      rarity: "common",
+      setId: "wildwood",
+      damage: 0,
+      health: 0,
+      baseCost: 1,
+    },
+    {
+      id: "spirit-bond",
+      name: "Spirit Bond",
+      rarity: "common",
+      setId: "wildwood",
+      damage: 0,
+      health: 0,
+      baseCost: 3,
+    },
+    {
+      id: "entangling-roots",
+      name: "Entangling Roots",
+      rarity: "common",
+      setId: "wildwood",
+      damage: 0,
+      health: 0,
+      baseCost: 2,
+    },
+    {
+      id: "grove-protector",
+      name: "Grove Protector",
+      rarity: "common",
+      setId: "wildwood",
+      damage: 3,
+      health: 7,
+      baseCost: 5,
+    },
+    {
+      id: "wild-growth",
+      name: "Wild Growth",
+      rarity: "common",
+      setId: "wildwood",
+      damage: 0,
+      health: 0,
+      baseCost: 3,
+    },
+    {
+      id: "mystic-owl",
+      name: "Mystic Owl",
+      rarity: "common",
+      setId: "wildwood",
+      damage: 1,
+      health: 2,
+      baseCost: 2,
+    },
+    {
+      id: "sacred-grove",
+      name: "Sacred Grove",
+      rarity: "common",
+      setId: "wildwood",
+      damage: 0,
+      health: 0,
+      baseCost: 4,
+    },
+  ];
+
+  const duelProfiles = {
+    "lumen-oracle": {
+      cardType: "spell",
+      damage: 0,
+      health: 0,
+      text: "Zauber: Heilt deinen Helden um 4 Lebenspunkte.",
+      effect: { type: "healHero", amount: 4 },
+    },
+    "astral-herald": {
+      cardType: "spell",
+      damage: 3,
+      health: 0,
+      text: "Zauber: Fügt dem gegnerischen Helden 3 Schaden zu.",
+      effect: { type: "directDamage", amount: 3 },
+    },
+    "sunscale-sentinel": {
+      abilities: ["bulwark"],
+      text: "Bollwerk: Gegnerische Karten müssen zuerst diese Einheit angreifen.",
+    },
+    "zenith-guardian": {
+      abilities: ["bulwark"],
+      text: "Bollwerk: Schützt den Helden vor direkten Angriffen.",
+    },
+    "gearworn-scribe": {
+      cardType: "spell",
+      damage: 2,
+      health: 0,
+      text: "Zauber: Verursacht 2 Schaden an einer gegnerischen Karte.",
+      effect: { type: "enemyUnitDamage", amount: 2 },
+    },
+    "void-chimes": {
+      cardType: "spell",
+      damage: 1,
+      health: 0,
+      text: "Zauber: Verursacht allen gegnerischen Karten 1 Schaden.",
+      effect: { type: "damageAllEnemies", amount: 1 },
+    },
+    "apex-colossus": {
+      abilities: ["bulwark"],
+      text: "Bollwerk: Erzwingt Angriffe auf diese gewaltige Konstruktion.",
+    },
+    "ancient-treant": {
+      abilities: ["bulwark"],
+      text: "Bollwerk: Schirmt den Hüter zuverlässig ab.",
+    },
+    "avatar-of-the-grove": {
+      text: "Beim Ausspielen: Verbündete Diener erhalten dauerhaft +2 Barriere.",
+    },
+    "elder-dryad": {
+      text: "Solange sie im Spiel ist, kosten eure Zauber 1 Kristall weniger.",
+    },
+    "forest-guardian": {
+      abilities: ["bulwark"],
+      text: "Bollwerk: Andere Wald-Einheiten erhalten +1 Barriere.",
+    },
+    "druid-of-the-grove": {
+      text: "Beim Ausspielen: Wählt, ob 6 geheilt oder 6 Schaden verursacht werden.",
+    },
+    "sylvan-huntress": {
+      text: "Beim Ausspielen greift sie sofort ein Ziel an.",
+    },
+    "spirit-of-renewal": {
+      text: "Heilt am Ende jedes Zuges euren Helden um 2 Leben.",
+    },
+    "oakheart-sentinel": {
+      abilities: ["bulwark"],
+      text: "Bollwerk: Blockt den ersten Angriff, der diesen Zug kommt.",
+    },
+    "wolfkin-alpha": {
+      text: "Alle eure Bestien erhalten +1 Schaden.",
+    },
+    "vinewhisper-druid": {
+      text: "Beim Ausspielen zieht ihr 1 Karte.",
+    },
+    "natures-fury": {
+      cardType: "spell",
+      text: "Zauber: Verursacht 3 Schaden an allen feindlichen Dienern.",
+      effect: { type: "damageAllEnemies", amount: 3 },
+    },
+    "blessing-of-roots": {
+      cardType: "spell",
+      text: "Zauber: Verleiht einem Diener dauerhaft +2 Barriere.",
+      effect: { type: "grantBarrier", amount: 2 },
+    },
+    "call-of-the-wild": {
+      cardType: "spell",
+      text: "Zauber: Beschwört 2 Wolf Spirits (2/2).",
+      effect: { type: "summonUnits", cardId: "wolf-spirit", count: 2 },
+    },
+    "ancient-ritual": {
+      cardType: "spell",
+      text: "Zauber: Heilt alle eure Diener um 3 Leben.",
+      effect: { type: "healAllies", amount: 3 },
+    },
+    "woodland-archer": {
+      text: "Fernkampf: Greift aus sicherer Distanz an.",
+    },
+    "spriggan-scout": {
+      text: "Beim Ausspielen zieht ihr 1 Karte.",
+    },
+    "thorned-beast": {
+      text: "Fügt Angreifern 1 Schaden zu.",
+    },
+    "healing-stream": {
+      cardType: "spell",
+      text: "Zauber: Heilt euren Helden um 5 Leben.",
+      effect: { type: "healHero", amount: 5 },
+    },
+    "forest-blessing": {
+      cardType: "spell",
+      text: "Zauber: Alle eure Diener erhalten dauerhaft +1 Schaden.",
+      effect: { type: "buffAlliesAttack", amount: 1 },
+    },
+    "barkskin": {
+      cardType: "spell",
+      text: "Zauber: Ein Diener erhält dauerhaft +3 Barriere.",
+      effect: { type: "grantBarrier", amount: 3 },
+    },
+    "woodland-sprite": {
+      text: "Beim Ausspielen heilt sie 2 Leben.",
+    },
+    "treant-sapling": {
+      text: "Erhält +1/+1, wenn ihr einen Wald-Zauber spielt.",
+    },
+    "sylvan-strike": {
+      cardType: "spell",
+      text: "Zauber: Fügt einem Diener 2 Schaden zu.",
+      effect: { type: "enemyUnitDamage", amount: 2 },
+    },
+    "spirit-bond": {
+      cardType: "spell",
+      text: "Zauber: Ein Diener darf in diesem Zug zweimal angreifen.",
+      effect: { type: "grantExtraAttack" },
+    },
+    "entangling-roots": {
+      cardType: "spell",
+      text: "Zauber: Lähmt einen gegnerischen Diener für 1 Zug.",
+      effect: { type: "stun", duration: 1 },
+    },
+    "grove-protector": {
+      abilities: ["bulwark"],
+      text: "Bollwerk: Verhindert den ersten Zauber, der euch in diesem Zug trifft.",
+    },
+    "wild-growth": {
+      cardType: "spell",
+      text: "Zauber: Zieht 2 Karten.",
+      effect: { type: "drawCards", amount: 2 },
+    },
+    "mystic-owl": {
+      text: "Beim Ausspielen schaut ihr euch die oberste Karte eures Decks an.",
+    },
+    "sacred-grove": {
+      cardType: "spell",
+      text: "Zauber: Heilt alle eure Diener um 2 und verleiht +1 Barriere.",
+      effect: { type: "healAndFortifyAllies", heal: 2, barrier: 1 },
+    },
+  };
+
+  allItems.forEach((item) => {
+    const profile = duelProfiles[item.id];
+    if (profile) {
+      Object.assign(item, profile);
+    }
+    item.cardType = item.cardType ?? "unit";
+    if (profile?.abilities) {
+      item.abilities = profile.abilities.slice();
+    } else if (Array.isArray(item.abilities)) {
+      item.abilities = item.abilities.slice();
+    } else {
+      item.abilities = [];
+    }
+    const estimated = estimateCardCost(item);
+    const fixedCost = Number.isFinite(item.baseCost) ? Number(item.baseCost) : undefined;
+    if (Number.isFinite(fixedCost)) {
+      item.cost = Math.max(0, Math.min(10, Math.round(fixedCost)));
+    } else {
+      item.cost = Math.max(1, Math.min(10, Math.round(estimated)));
+    }
+  });
+
+  const statIcons = {
+    cost:
+      '<svg class="card-stat-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M12 2 3 10.5 12 22l9-11.5z" fill="currentColor"/><path d="M12 5 6.4 10.5 12 18l5.6-7.5z" fill="currentColor" opacity="0.45"/></svg>',
+    damage:
+      '<svg class="card-stat-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M12 2l2.7 6.2 6.3 1.1-4.5 3.9 1.3 6.8L12 17.1 6.2 20l1.3-6.8L3 9.3l6.3-1.1z" fill="currentColor"/></svg>',
+    health:
+      '<svg class="card-stat-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M12 21s-5.7-4-8.6-7.8C0.8 10.6 1.8 5 6.2 5c2.3 0 3.8 1.4 5.8 3.7C14 6.4 15.5 5 17.8 5c4.4 0 5.4 5.6 2.8 8.2C17.7 17 12 21 12 21z" fill="currentColor"/></svg>',
+  };
+
+  const globalScope = typeof window !== "undefined" ? window : (typeof globalThis !== "undefined" ? globalThis : {});
+
+  function getEmbeddedArtMap() {
+    const artMap = globalScope.embeddedCardArt;
+    return artMap instanceof Map ? artMap : null;
+  }
+
+  function getEmbeddedFullArt(id) {
+    const artMap = getEmbeddedArtMap();
+    if (!artMap) {
+      return "";
+    }
+    const art = artMap.get(id);
+    return typeof art === "string" ? art : "";
+  }
+
+  const cardIllustrations = new Map([
+    ["aurora-scribe", { icon: "🖋️" }],
+    ["lumen-oracle", { icon: "🔮" }],
+    ["starlit-vanguard", { icon: "⚔️" }],
+    ["echo-wanderer", { icon: "🌌" }],
+    ["astral-herald", { icon: "📯" }],
+    ["nebula-mender", { icon: "✨" }],
+    ["rift-cartographer", { icon: "🗺️" }],
+    ["sunscale-sentinel", { icon: "🌞", gradient: ["#ffd166", "#ff7b54"], accent: "#fff6d5" }],
+    ["nova-chronicler", { icon: "📜" }],
+    ["zenith-guardian", { icon: "🛡️" }],
+    ["moonweaver-seraph", { icon: "🌙", gradient: ["#8b5cf6", "#22d3ee"], accent: "#f5f3ff" }],
+    ["aether-crown", { icon: "👑" }],
+    ["ember-solstice-phoenix", { icon: "🔥", gradient: ["#ff9f43", "#ff3366"], accent: "#fff4d6" }],
+    ["cogwhisper-sprite", { icon: "⚙️" }],
+    ["emberplated-scout", { icon: "🤖" }],
+    ["copper-harvester", { icon: "⚒️" }],
+    ["gearworn-scribe", { icon: "📘" }],
+    ["chronomancer-apprentice", { icon: "⏳" }],
+    ["steamwright-mediator", { icon: "🔧" }],
+    ["gilded-engine", { icon: "🏭" }],
+    ["void-chimes", { icon: "🔔" }],
+    ["apex-colossus", { icon: "🗼" }],
+    ["heart-of-mechanis", { icon: "💠", gradient: ["#ffbe6b", "#f97316"], accent: "#fff1d6" }],
+    ["ancient-treant", { embeddedKey: "ancient-treant", layout: "full" }],
+    ["avatar-of-the-grove", { embeddedKey: "avatar-of-the-grove", layout: "full" }],
+    ["elder-dryad", { embeddedKey: "elder-dryad", layout: "full" }],
+    ["forest-guardian", { embeddedKey: "forest-guardian", layout: "full" }],
+    ["druid-of-the-grove", { embeddedKey: "druid-of-the-grove", layout: "full" }],
+    ["sylvan-huntress", { icon: "🏹" }],
+    ["spirit-of-renewal", { icon: "💚" }],
+    ["oakheart-sentinel", { icon: "🪵" }],
+    ["wolfkin-alpha", { icon: "🐺" }],
+    ["vinewhisper-druid", { icon: "🍃" }],
+    ["natures-fury", { icon: "🌪️" }],
+    ["blessing-of-roots", { icon: "🌱" }],
+    ["call-of-the-wild", { icon: "🐾" }],
+    ["ancient-ritual", { icon: "🔮" }],
+    ["woodland-archer", { icon: "🏹" }],
+    ["spriggan-scout", { icon: "🧚" }],
+    ["thorned-beast", { icon: "🦔" }],
+    ["healing-stream", { icon: "💧" }],
+    ["forest-blessing", { icon: "✨" }],
+    ["barkskin", { icon: "🌲" }],
+    ["woodland-sprite", { icon: "🧝" }],
+    ["wolf-spirit", { icon: "🐺", gradient: ["#cfd8dc", "#607d8b"], accent: "#f5f7fa" }],
+    ["treant-sapling", { icon: "🌱" }],
+    ["sylvan-strike", { icon: "⚡" }],
+    ["spirit-bond", { icon: "🔗" }],
+    ["entangling-roots", { icon: "🪢" }],
+    ["grove-protector", { icon: "🛡️", gradient: ["#81c784", "#33691e"], accent: "#eaffea" }],
+    ["wild-growth", { icon: "🌿" }],
+    ["mystic-owl", { icon: "🦉" }],
+    ["sacred-grove", { icon: "🏞️" }],
+  ]);
+
+  function resolveAssetUri(fileName) {
+    if (typeof fileName !== "string" || fileName.length === 0) {
+      return "";
+    }
+    const relativePath = fileName.startsWith("./") || fileName.startsWith("/") ? fileName : `assets/${fileName}`;
+    if (typeof document !== "undefined") {
+      try {
+        const base = document.baseURI ?? window.location?.href ?? "";
+        return new URL(relativePath, base).href;
+      } catch (error) {
+        return relativePath;
+      }
+    }
+    return relativePath;
+  }
+
+  function usesFullCardArtwork(item) {
+    if (!item) {
+      return false;
+    }
+    const artConfig = cardIllustrations.get(item.id);
+    if (!artConfig) {
+      return false;
+    }
+    const expectsFullLayout = artConfig.layout === "full" || artConfig.fullCard === true;
+    if (!expectsFullLayout) {
+      return false;
+    }
+    if (typeof artConfig.image === "string" && artConfig.image.length > 0) {
+      return true;
+    }
+    const key = typeof artConfig.embeddedKey === "string" ? artConfig.embeddedKey : item.id;
+    return getEmbeddedFullArt(key).length > 0;
+  }
+
+  const defaultArtBySet = {
+    celestial: {
+      icon: "✨",
+      motif: "orbit",
+      accent: "#f7f3ff",
+      secondary: "rgba(233, 225, 255, 0.45)",
+      overlay: "rgba(18, 22, 44, 0.45)",
+    },
+    clockwork: {
+      icon: "⚙️",
+      motif: "mechanical",
+      accent: "#ffe6c9",
+      secondary: "rgba(255, 200, 160, 0.45)",
+      overlay: "rgba(39, 22, 8, 0.45)",
+    },
+    wildwood: {
+      icon: "🍃",
+      motif: "flora",
+      accent: "#e6ffe8",
+      secondary: "rgba(176, 255, 210, 0.45)",
+      overlay: "rgba(6, 32, 18, 0.4)",
+    },
+  };
+
+  const setGradientBase = {
+    celestial: 248,
+    clockwork: 32,
+    wildwood: 138,
+  };
+
+  const cardArtCache = new Map();
+
+  const packDefinitions = [
+    {
+      id: "celestial-pack",
+      name: "Celestial Echo Pack",
+      setId: "celestial",
+      description: "Standard-Booster für die himmlischen Karten.",
+      cardsPerPack: 5,
+      dropTable: [
+        { rarity: "common", chance: 0.65 },
+        { rarity: "uncommon", chance: 0.2 },
+        { rarity: "rare", chance: 0.1 },
+        { rarity: "epic", chance: 0.04 },
+        { rarity: "legendary", chance: 0.01 },
+      ],
+    },
+    {
+      id: "clockwork-pack",
+      name: "Clockwork Depth Pack",
+      setId: "clockwork",
+      description: "Mechanische Relikte aus den Tiefen der See.",
+      cardsPerPack: 5,
+      dropTable: [
+        { rarity: "common", chance: 0.6 },
+        { rarity: "uncommon", chance: 0.22 },
+        { rarity: "rare", chance: 0.12 },
+        { rarity: "epic", chance: 0.05 },
+        { rarity: "legendary", chance: 0.01 },
+      ],
+    },
+    {
+      id: "wildwood-pack",
+      name: "Wildwood Bloom Pack",
+      setId: "wildwood",
+      description: "Flirrende Naturgeister und Neon-Biome.",
+      cardsPerPack: 5,
+      dropTable: [
+        { rarity: "common", chance: 0.6 },
+        { rarity: "uncommon", chance: 0.24 },
+        { rarity: "rare", chance: 0.1 },
+        { rarity: "epic", chance: 0.05 },
+        { rarity: "legendary", chance: 0.01 },
+      ],
+    },
+    {
+      id: "event-pack",
+      name: "Ember Solstice Pack",
+      setId: "celestial",
+      description: "Event-Booster mit erhöhter Chance auf Event-Legendaries.",
+      cardsPerPack: 5,
+      dropTable: [
+        { rarity: "common", chance: 0.55 },
+        { rarity: "uncommon", chance: 0.2 },
+        { rarity: "rare", chance: 0.15 },
+        { rarity: "epic", chance: 0.07 },
+        { rarity: "legendary", chance: 0.03 },
+      ],
+      isEvent: true,
+      specialItemId: "ember-solstice-phoenix",
+      specialChance: 0.15,
+    },
+  ];
+
+  const storageKeys = {
+    collection: "cfRareHunt_collection",
+    login: "cfRareHunt_login",
+    event: "cfRareHunt_event",
+  };
+
+  const duelConfig = {
+    startingHealth: 30,
+    startingHandSize: 3,
+    maxCrystals: 10,
+    deckSize: 30,
+    boardLimit: 6,
+    logLimit: 60,
+  };
+
+  const duelDefaultNames = ["Sammler Nova", "Archivjäger Vega"];
+
+  const supportsStorage = (() => {
+    try {
+      const testKey = "cfRareHunt_test";
+      window.localStorage.setItem(testKey, "1");
+      window.localStorage.removeItem(testKey);
+      return true;
+    } catch (error) {
+      return false;
+    }
+  })();
+
+  const setsById = new Map(sets.map((set) => [set.id, set]));
+  const setOrder = new Map(sets.map((set, index) => [set.id, index]));
+  const itemsById = new Map(allItems.map((item) => [item.id, item]));
+  const limitedEventItem = itemsById.get("ember-solstice-phoenix");
+
+  let collectionState = loadCollection();
+  const structureChanged = ensureCollectionStructure();
+  const deckBuilderState = {
+    name: collectionState.deck?.name ?? "Arena-Starter",
+    workingCards: cloneDeckCards(collectionState.deck?.cards ?? {}),
+    dirty: false,
+    status: undefined,
+  };
+  const collectionFilters = {
+    search: "",
+    setId: "all",
+    rarity: "all",
+    sort: "rarity-desc",
+    ownedOnly: true,
+    duplicatesOnly: false,
+  };
+
+  const duelState = {
+    status: "idle",
+    players: duelDefaultNames.map((name) => createIdlePlayerState(name)),
+    activePlayer: 0,
+    turnCounter: 0,
+    log: [],
+    winner: undefined,
+    nextUnitId: 1,
+  };
+
+  const duelInteraction = {
+    mode: "idle",
+    sourcePlayer: undefined,
+    sourceUnitId: undefined,
+    pendingSpell: undefined,
+    targets: [],
+    targetKeys: new Set(),
+  };
+  updateDeckBuilderDirtyState();
+  if (structureChanged) {
+    saveCollection();
+  }
+  let loginState = loadLoginState();
+  const eventState = loadEventState();
+
+  const dom = {};
+  const sliderState = {
+    viewport: undefined,
+    track: undefined,
+    panels: [],
+    navLinks: [],
+  };
+  let activePanelId;
+  let panelScrollRaf = 0;
+  const deckbuilderCarouselControllers = new WeakMap();
+  const deckbuilderCarouselPresets = {
+    pool: {
+      mode: "collection",
+      baseScale: 0.9,
+      focusScale: 1.16,
+      maxTilt: 14,
+      friction: 0.0024,
+      maxVelocity: 4.4,
+      lift: 0,
+      wheelFactor: 1.1,
+      allowMomentum: true,
+    },
+    selection: {
+      mode: "deck",
+      baseScale: 0.96,
+      focusScale: 1.08,
+      maxTilt: 6,
+      friction: 0.0028,
+      maxVelocity: 3.6,
+      lift: 0,
+      wheelFactor: 1,
+      allowMomentum: true,
+    },
+  };
+
+  init();
+
+  function init() {
+    dom.packSelect = document.getElementById("pack-select");
+    dom.packResults = document.getElementById("pack-results");
+    dom.openPackBtn = document.getElementById("open-pack");
+    dom.eventPackBtn = document.getElementById("event-pack-btn");
+    dom.totalOwned = document.getElementById("total-owned");
+    dom.uniqueOwned = document.getElementById("unique-owned");
+    dom.completedSets = document.getElementById("completed-sets");
+    dom.collectionGrid = document.getElementById("collection-grid");
+    dom.tradeList = document.getElementById("trade-list");
+    dom.collectionCards = document.getElementById("collection-card-grid");
+    dom.collectionEmpty = document.getElementById("collection-empty");
+    dom.collectionFilterSummary = document.getElementById("collection-filter-summary");
+    dom.collectionSearch = document.getElementById("collection-search");
+    dom.collectionSetFilter = document.getElementById("collection-filter-set");
+    dom.collectionRarityFilter = document.getElementById("collection-filter-rarity");
+    dom.collectionSort = document.getElementById("collection-sort");
+    dom.collectionOwnedToggle = document.getElementById("collection-owned-toggle");
+    dom.collectionDuplicatesToggle = document.getElementById("collection-duplicates-toggle");
+    dom.deckBuilderSection = document.getElementById("deckbuilder");
+    dom.deckBuilderStatus = document.getElementById("deckbuilder-status");
+    dom.deckBuilderName = document.getElementById("deckbuilder-name");
+    dom.deckBuilderSave = document.getElementById("deckbuilder-save");
+    dom.deckBuilderReset = document.getElementById("deckbuilder-reset");
+    dom.deckBuilderCount = document.getElementById("deckbuilder-count");
+    dom.deckBuilderPool = document.getElementById("deckbuilder-card-pool");
+    dom.deckBuilderSelection = document.getElementById("deckbuilder-selection");
+    dom.dailyStreak = document.getElementById("daily-streak");
+    dom.loginStatus = document.getElementById("login-status");
+    dom.claimLogin = document.getElementById("claim-login");
+    dom.nextMilestone = document.getElementById("next-milestone");
+    dom.dailyReward = document.getElementById("daily-reward-display");
+    dom.eventCountdown = document.getElementById("event-countdown");
+    dom.eventItem = document.getElementById("event-item");
+    dom.heroStreak = document.getElementById("hero-streak");
+    dom.activeSetCount = document.getElementById("active-set-count");
+    dom.legendaryHighlight = document.getElementById("legendary-highlight");
+    dom.ctaOpenPack = document.getElementById("cta-open-pack");
+    dom.ctaExplore = document.getElementById("cta-explore");
+    dom.duelStart = document.getElementById("duel-start");
+    dom.duelEndTurn = document.getElementById("duel-end-turn");
+    dom.duelRound = document.getElementById("duel-round");
+    dom.duelActive = document.getElementById("duel-active");
+    dom.duelLog = document.getElementById("duel-log");
+    dom.duelTargetPanel = document.getElementById("duel-target-panel");
+    dom.duelTargetMessage = document.getElementById("duel-target-message");
+    dom.duelTargetList = document.getElementById("duel-target-list");
+    dom.duelTargetCancel = document.getElementById("duel-target-cancel");
+    dom.duelDecklistRoot = document.querySelector("[data-duel-decklist-root]");
+    dom.duelDecklist = document.querySelector("[data-duel-decklist]");
+
+    sliderState.viewport = document.getElementById("panel-viewport");
+    sliderState.track = document.getElementById("panel-track");
+    sliderState.panels = sliderState.track
+      ? Array.from(sliderState.track.querySelectorAll(".panel"))
+      : [];
+    sliderState.navLinks = Array.from(
+      document.querySelectorAll(".nav-links a[data-panel-target]")
+    );
+
+    setupPanelSlider();
+
+    populatePackSelect();
+    renderSetCards();
+    setupCollectionViewer();
+    setupDeckBuilder();
+    updateCollectionUI();
+    updateDailyLoginUI();
+    setupEventCountdown();
+    updateHeroStats();
+    handlePackSelection();
+    setupMultiplayerArena();
+
+    dom.openPackBtn.addEventListener("click", handlePackOpen);
+    dom.packSelect.addEventListener("change", handlePackSelection);
+    dom.claimLogin.addEventListener("click", claimDailyReward);
+    dom.ctaOpenPack.addEventListener("click", () => scrollToSection("pack-lab"));
+    dom.ctaExplore.addEventListener("click", () => scrollToSection("deckbuilder"));
+
+    if (dom.eventPackBtn) {
+      dom.eventPackBtn.addEventListener("click", () => {
+        const eventPack = packDefinitions.find((pack) => pack.isEvent);
+        if (!eventPack) {
+          return;
+        }
+        dom.packSelect.value = eventPack.id;
+        handlePackOpen();
+      });
+    }
+  }
+
+  function populatePackSelect() {
+    dom.packSelect.innerHTML = "";
+    packDefinitions.forEach((pack) => {
+      const option = document.createElement("option");
+      option.value = pack.id;
+      option.textContent = pack.isEvent ? `🔥 ${pack.name}` : pack.name;
+      dom.packSelect.append(option);
+    });
+  }
+
+  function renderSetCards() {
+    dom.collectionGrid.innerHTML = "";
+    sets.forEach((set) => {
+      const card = document.createElement("article");
+      card.className = "set-card";
+      card.dataset.setId = set.id;
+      card.innerHTML = `
+        <h3>${set.name}</h3>
+        <p>${set.description}</p>
+        <div class="progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="${set.total}" aria-valuenow="0">
+          <span style="width:0%"></span>
+        </div>
+        <footer>
+          <span class="stat-label">Fortschritt</span>
+          <strong class="progress-count">0 / ${set.total}</strong>
+        </footer>
+      `;
+      dom.collectionGrid.append(card);
+    });
+  }
+
+  function handlePackSelection() {
+    const pack = packDefinitions.find((entry) => entry.id === dom.packSelect.value);
+    if (!pack) {
+      return;
+    }
+    const description = document.createElement("p");
+    description.className = "pack-summary";
+    description.textContent = pack.description;
+    dom.packResults.innerHTML = "";
+    dom.packResults.append(description);
+  }
+
+  function handlePackOpen() {
+    const pack = packDefinitions.find((entry) => entry.id === dom.packSelect.value);
+    if (!pack) {
+      return;
+    }
+
+    const drops = rollPack(pack);
+    drops.forEach((item) => addItemToCollection(item.id, 1));
+    saveCollection();
+    displayPackResults(pack, drops);
+    updateCollectionUI();
+    updateHeroStats();
+  }
+
+  function rollPack(pack) {
+    const drops = [];
+    const cardsPerPack = pack.cardsPerPack ?? 5;
+    for (let i = 0; i < cardsPerPack; i += 1) {
+      if (pack.specialItemId && Math.random() < (pack.specialChance ?? 0)) {
+        const special = itemsById.get(pack.specialItemId);
+        if (special) {
+          drops.push(special);
+          continue;
+        }
+      }
+      const rarity = pickRarity(pack.dropTable);
+      const pool = allItems.filter((item) => {
+        if (item.setId !== pack.setId) {
+          return false;
+        }
+        if (item.isLimited && !pack.isEvent) {
+          return false;
+        }
+        return item.rarity === rarity;
+      });
+      const candidates = pool.length > 0 ? pool : allItems.filter((item) => item.setId === pack.setId);
+      const item = candidates[Math.floor(Math.random() * candidates.length)];
+      drops.push(item);
+    }
+    return drops;
+  }
+
+  function pickRarity(table) {
+    const roll = Math.random();
+    let cumulative = 0;
+    for (const entry of table) {
+      cumulative += entry.chance;
+      if (roll <= cumulative) {
+        return entry.rarity;
+      }
+    }
+    return table[table.length - 1]?.rarity ?? "common";
+  }
+
+  function addItemToCollection(itemId, quantity) {
+    const amount = quantity ?? 1;
+    if (!collectionState.items) {
+      collectionState.items = {};
+    }
+    collectionState.items[itemId] = (collectionState.items[itemId] ?? 0) + amount;
+  }
+
+  function displayPackResults(pack, drops) {
+    dom.packResults.innerHTML = "";
+    const summary = document.createElement("div");
+    summary.className = "pack-summary";
+    const rarityCounts = drops.reduce((acc, item) => {
+      acc[item.rarity] = (acc[item.rarity] ?? 0) + 1;
+      return acc;
+    }, {});
+    const summaryText = Object.entries(rarityCounts)
+      .map(([rarity, count]) => `${count}× ${rarityLabels[rarity]}`)
+      .join(" · ");
+    summary.innerHTML = `<span>${pack.name}</span><strong>${summaryText}</strong>`;
+    dom.packResults.append(summary);
+
+    const grid = document.createElement("div");
+    grid.className = "card-grid";
+    drops.forEach((item) => {
+      const card = createCardElement(item);
+      grid.append(card);
+    });
+    dom.packResults.append(grid);
+  }
+
+  function buildCardMeta(item) {
+    const set = setsById.get(item.setId);
+    const typeParts = [];
+    if (item.cardType === "spell") {
+      typeParts.push("Zauber");
+    } else {
+      typeParts.push("Einheit");
+      if (Array.isArray(item.abilities) && item.abilities.includes("bulwark")) {
+        typeParts.push("Bollwerk");
+      }
+    }
+    const damageLabel = item.cardType === "spell" ? "Zauberschaden" : "Angriff";
+    const healthLabel = item.cardType === "spell" ? "Zauberschutz" : "Lebenspunkte";
+    const rawDamage = Number.isFinite(item.damage) ? item.damage : 0;
+    const rawHealth = Number.isFinite(item.health) ? item.health : 0;
+    const damageValue =
+      item.cardType === "spell" ? (rawDamage > 0 ? String(rawDamage) : "–") : String(rawDamage);
+    const healthValue = item.cardType === "spell" ? "–" : String(rawHealth);
+    return {
+      setName: set?.name ?? "",
+      typeLabel: typeParts.join(" · "),
+      damageLabel,
+      healthLabel,
+      damageValue,
+      healthValue,
+    };
+  }
+
+  function getCardAccessibilitySummary(item, quantity, meta) {
+    if (!item) {
+      return "";
+    }
+    const summaryParts = [];
+    if (item.name) {
+      summaryParts.push(item.name);
+    }
+    if (meta?.setName) {
+      summaryParts.push(`Set ${meta.setName}`);
+    }
+    if (meta?.typeLabel) {
+      summaryParts.push(meta.typeLabel);
+    }
+    if (Number.isFinite(item.cost)) {
+      summaryParts.push(`Kosten ${item.cost}`);
+    }
+    if (meta?.damageValue && meta.damageValue !== "–") {
+      summaryParts.push(`${meta.damageLabel} ${meta.damageValue}`);
+    }
+    if (meta?.healthValue && meta.healthValue !== "–") {
+      summaryParts.push(`${meta.healthLabel} ${meta.healthValue}`);
+    }
+    if (item.text) {
+      summaryParts.push(item.text);
+    }
+    if (item.isLimited) {
+      summaryParts.push("Event Limited");
+    }
+    if (quantity > 1) {
+      summaryParts.push(`Anzahl ${quantity}`);
+    }
+    return summaryParts.join(". ");
+  }
+
+  function createSrOnlyText(text) {
+    if (!text) {
+      return null;
+    }
+    const span = document.createElement("span");
+    span.className = "sr-only";
+    span.textContent = text;
+    return span;
+  }
+
+  function createCardElement(item, options) {
+    const card = document.createElement("article");
+    card.className = `card rarity-${item.rarity}`;
+    const rarityLabel = rarityLabels[item.rarity] ?? item.rarity;
+    const quantity = options?.quantity ?? 0;
+    const meta = buildCardMeta(item);
+    const artUri = getCardArtUri(item);
+    const artAltText = `Illustration von ${item.name}`;
+    const artAlt = escapeXml(artAltText);
+    const cardName = escapeXml(item.name);
+    const cardSet = escapeXml(meta.setName);
+    const typeLabel = escapeXml(meta.typeLabel);
+    const damageStat = meta.damageValue;
+    const healthStat = meta.healthValue;
+    const cardText = item.text ? `<p class="card-text">${escapeXml(item.text)}</p>` : "";
+    const limitedTag = item.isLimited ? '<span class="tag limited">Event Limited</span>' : "";
+    const quantityTag = quantity > 1 ? `<span class="card-qty">×${quantity}</span>` : "";
+    const usesFullArt = usesFullCardArtwork(item);
+    const srSummary = getCardAccessibilitySummary(item, quantity, meta);
+    if (usesFullArt) {
+      card.classList.add("card--full-art");
+      const figure = document.createElement("figure");
+      figure.className = "card-full-art";
+      const img = document.createElement("img");
+      img.src = artUri;
+      img.alt = artAltText;
+      img.loading = "lazy";
+      figure.append(img);
+      if (item.isLimited) {
+        const flag = document.createElement("span");
+        flag.className = "tag limited card-flag--overlay";
+        flag.textContent = "Event Limited";
+        figure.append(flag);
+      }
+      if (quantity > 1) {
+        const qtyBadge = document.createElement("span");
+        qtyBadge.className = "card-qty card-qty--overlay";
+        qtyBadge.textContent = `×${quantity}`;
+        figure.append(qtyBadge);
+      }
+      card.append(figure);
+      const srText = createSrOnlyText(srSummary);
+      if (srText) {
+        card.append(srText);
+      }
+      return card;
+    }
+    card.innerHTML = `
+      <figure class="card-illustration">
+        <img src="${artUri}" alt="${artAlt}" loading="lazy" />
+      </figure>
+      <div class="card-content">
+        <div class="card-header">
+          <span class="card-rarity">${rarityLabel}</span>
+          ${quantityTag}
+        </div>
+        <strong>${cardName}</strong>
+        <span class="card-type">${typeLabel}</span>
+        <p class="card-set">${cardSet}</p>
+        <div class="card-stats" role="group" aria-label="Kartenwerte">
+          <span class="card-stat card-stat--cost">${statIcons.cost}<span>${item.cost}</span></span>
+          <span class="card-stat card-stat--damage">${statIcons.damage}<span>${damageStat}</span></span>
+          <span class="card-stat card-stat--health">${statIcons.health}<span>${healthStat}</span></span>
+        </div>
+        ${cardText}
+        ${limitedTag ? `<div class="card-flags">${limitedTag}</div>` : ""}
+      </div>
+    `;
+    return card;
+  }
+
+  function getCardArtUri(item) {
+    const cached = cardArtCache.get(item.id);
+    if (cached) {
+      return cached;
+    }
+    const artConfig = cardIllustrations.get(item.id) ?? {};
+    const embeddedKey = typeof artConfig.embeddedKey === "string" ? artConfig.embeddedKey : null;
+    if (embeddedKey) {
+      const embeddedArt = getEmbeddedFullArt(embeddedKey);
+      if (embeddedArt.length > 0) {
+        cardArtCache.set(item.id, embeddedArt);
+        return embeddedArt;
+      }
+    }
+    if (typeof artConfig.asset === "string" && artConfig.asset.length > 0) {
+      const assetUri = resolveAssetUri(artConfig.asset);
+      cardArtCache.set(item.id, assetUri);
+      return assetUri;
+    }
+    if (typeof artConfig.image === "string" && artConfig.image.length > 0) {
+      cardArtCache.set(item.id, artConfig.image);
+      return artConfig.image;
+    }
+    const fallbackDefaults = defaultArtBySet.celestial ?? {};
+    const defaults = defaultArtBySet[item.setId] ?? fallbackDefaults;
+    const icon = artConfig.icon ?? defaults.icon ?? "✨";
+    const motif = artConfig.motif ?? defaults.motif ?? "orbit";
+    const gradient = deriveGradient(item, artConfig);
+    const accent = deriveAccent(item, artConfig);
+    const secondary = deriveSecondary(item, artConfig);
+    const overlay = deriveOverlay(item, artConfig);
+    const svg = createCardArtSvg({ icon, gradient, accent, secondary, motif, overlay });
+    const uri = svgToDataUri(svg);
+    if (!embeddedKey) {
+      cardArtCache.set(item.id, uri);
+    }
+    return uri;
+  }
+
+  function createCardArtSvg({ icon, gradient, accent, secondary, motif, overlay }) {
+    const [start, end] = gradient;
+    const motifShapes = renderMotif(motif, accent, secondary);
+    const iconText = escapeXml(icon);
+    return `
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 200">
+        <defs>
+          <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stop-color="${start}" />
+            <stop offset="100%" stop-color="${end}" />
+          </linearGradient>
+        </defs>
+        <rect fill="url(#bg)" width="160" height="200" rx="22" ry="22" />
+        ${motifShapes}
+        <rect x="18" y="154" width="124" height="30" rx="14" fill="${overlay}" />
+        <text x="50%" y="58%" fill="${accent}" font-size="68" text-anchor="middle" dominant-baseline="middle" font-family="Space Grotesk, 'Segoe UI Symbol', 'Apple Color Emoji', sans-serif">${iconText}</text>
+      </svg>
+    `;
+  }
+
+  function renderMotif(motif, accent, secondary) {
+    if (motif === "mechanical") {
+      return `
+        <g fill="${secondary}" opacity="0.6">
+          <circle cx="46" cy="72" r="26" />
+          <circle cx="120" cy="58" r="18" />
+        </g>
+        <g fill="none" stroke="${accent}" stroke-width="3.5" stroke-linecap="round" opacity="0.45">
+          <circle cx="46" cy="72" r="14" />
+          <path d="M32 138h100" />
+          <path d="M96 46l28 12" />
+          <path d="M102 88l24 28" />
+        </g>
+        <g fill="${accent}" opacity="0.45">
+          <rect x="76" y="110" width="60" height="12" rx="6" transform="rotate(-8 106 116)" />
+          <rect x="34" y="118" width="24" height="24" rx="6" />
+        </g>
+      `;
+    }
+    if (motif === "flora") {
+      return `
+        <g fill="${secondary}" opacity="0.5">
+          <path d="M48 132c0-32 30-62 34-86 8 28 36 50 60 54-26 8-42 28-46 52-8-18-24-26-48-20z" />
+        </g>
+        <g fill="${accent}" opacity="0.55">
+          <path d="M58 118c16-6 30-22 34-38 6 14 18 24 30 28-16 6-28 18-30 30-8-8-18-14-34-20z" />
+          <circle cx="56" cy="68" r="10" />
+          <circle cx="112" cy="72" r="6" />
+        </g>
+        <g fill="none" stroke="${accent}" stroke-width="3" stroke-linecap="round" opacity="0.35">
+          <path d="M46 152c14-10 44-20 70-12" />
+        </g>
+      `;
+    }
+    return `
+      <g fill="none" stroke="${secondary}" stroke-width="3" opacity="0.45">
+        <circle cx="80" cy="74" r="46" />
+        <circle cx="80" cy="98" r="30" stroke-dasharray="12 8" />
+        <path d="M20 60c28 18 92 18 120 0" stroke-linecap="round" />
+      </g>
+      <g fill="${accent}" opacity="0.55">
+        <circle cx="126" cy="62" r="8" />
+        <circle cx="42" cy="50" r="5" />
+        <path d="M82 132c14 8 26 8 40 0" opacity="0.6" />
+      </g>
+    `;
+  }
+
+  function deriveGradient(item, artConfig) {
+    if (artConfig.gradient) {
+      return artConfig.gradient;
+    }
+    const baseHue = setGradientBase[item.setId] ?? 220;
+    const hash = hashString(item.id);
+    const rarityBoost = rarityScore[item.rarity] ?? 0;
+    const hueOffset = (hash % 40) - 20;
+    const hue1 = (baseHue + hueOffset + 360) % 360;
+    const hue2 = (hue1 + 36 + (hash % 12)) % 360;
+    const lightnessA = 58 + rarityBoost * 4;
+    const lightnessB = 38 + rarityBoost * 3;
+    return [`hsl(${hue1}deg, 82%, ${lightnessA}%)`, `hsl(${hue2}deg, 68%, ${lightnessB}%)`];
+  }
+
+  function deriveAccent(item, artConfig) {
+    if (artConfig.accent) {
+      return artConfig.accent;
+    }
+    const defaults = defaultArtBySet[item.setId];
+    if (defaults?.accent) {
+      return defaults.accent;
+    }
+    return "#f5f3ff";
+  }
+
+  function deriveSecondary(item, artConfig) {
+    if (artConfig.secondary) {
+      return artConfig.secondary;
+    }
+    const defaults = defaultArtBySet[item.setId];
+    if (defaults?.secondary) {
+      return defaults.secondary;
+    }
+    return "rgba(233, 225, 255, 0.45)";
+  }
+
+  function deriveOverlay(item, artConfig) {
+    if (artConfig.overlay) {
+      return artConfig.overlay;
+    }
+    const defaults = defaultArtBySet[item.setId];
+    if (defaults?.overlay) {
+      return defaults.overlay;
+    }
+    return "rgba(18, 22, 44, 0.45)";
+  }
+
+  function svgToDataUri(svg) {
+    return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+  }
+
+  function hashString(value) {
+    let hash = 0;
+    for (let i = 0; i < value.length; i += 1) {
+      hash = (hash << 5) - hash + value.charCodeAt(i);
+      hash |= 0;
+    }
+    return Math.abs(hash);
+  }
+
+  function escapeXml(value) {
+    return String(value)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  function setupCollectionViewer() {
+    if (!dom.collectionCards) {
+      return;
+    }
+
+    if (dom.collectionSetFilter) {
+      dom.collectionSetFilter.innerHTML = "";
+      const allOption = document.createElement("option");
+      allOption.value = "all";
+      allOption.textContent = "Alle Sets";
+      dom.collectionSetFilter.append(allOption);
+      sets.forEach((set) => {
+        const option = document.createElement("option");
+        option.value = set.id;
+        option.textContent = set.name;
+        dom.collectionSetFilter.append(option);
+      });
+      dom.collectionSetFilter.value = collectionFilters.setId;
+      dom.collectionSetFilter.addEventListener("change", (event) => {
+        const value = typeof event.target.value === "string" ? event.target.value : "all";
+        collectionFilters.setId = value && value !== "" ? value : "all";
+        renderCollectionGallery();
+      });
+    }
+
+    if (dom.collectionRarityFilter) {
+      dom.collectionRarityFilter.innerHTML = "";
+      const allOption = document.createElement("option");
+      allOption.value = "all";
+      allOption.textContent = "Alle Seltenheiten";
+      dom.collectionRarityFilter.append(allOption);
+      Object.entries(rarityLabels).forEach(([rarity, label]) => {
+        const option = document.createElement("option");
+        option.value = rarity;
+        option.textContent = label;
+        dom.collectionRarityFilter.append(option);
+      });
+      dom.collectionRarityFilter.value = collectionFilters.rarity;
+      dom.collectionRarityFilter.addEventListener("change", (event) => {
+        const value = typeof event.target.value === "string" ? event.target.value : "all";
+        collectionFilters.rarity = value && value !== "" ? value : "all";
+        renderCollectionGallery();
+      });
+    }
+
+    if (dom.collectionSort) {
+      const sortOptions = [
+        { value: "rarity-desc", label: "Rarität (hoch → niedrig)" },
+        { value: "cost-asc", label: "Kosten (aufsteigend)" },
+        { value: "cost-desc", label: "Kosten (absteigend)" },
+        { value: "name-asc", label: "Name (A–Z)" },
+        { value: "set-asc", label: "Set (A–Z)" },
+      ];
+      dom.collectionSort.innerHTML = "";
+      sortOptions.forEach((optionDef) => {
+        const option = document.createElement("option");
+        option.value = optionDef.value;
+        option.textContent = optionDef.label;
+        dom.collectionSort.append(option);
+      });
+      dom.collectionSort.value = collectionFilters.sort;
+      dom.collectionSort.addEventListener("change", (event) => {
+        const value = typeof event.target.value === "string" ? event.target.value : "rarity-desc";
+        collectionFilters.sort = value && value !== "" ? value : "rarity-desc";
+        renderCollectionGallery();
+      });
+    }
+
+    if (dom.collectionSearch) {
+      dom.collectionSearch.value = collectionFilters.search;
+      let searchDebounce;
+      dom.collectionSearch.addEventListener("input", (event) => {
+        const value = typeof event.target.value === "string" ? event.target.value : "";
+        collectionFilters.search = value;
+        if (searchDebounce) {
+          window.clearTimeout(searchDebounce);
+        }
+        searchDebounce = window.setTimeout(() => {
+          renderCollectionGallery();
+        }, 120);
+      });
+    }
+
+    if (dom.collectionOwnedToggle) {
+      dom.collectionOwnedToggle.checked = collectionFilters.ownedOnly;
+      dom.collectionOwnedToggle.addEventListener("change", (event) => {
+        collectionFilters.ownedOnly = Boolean(event.target.checked);
+        if (!collectionFilters.ownedOnly && collectionFilters.duplicatesOnly) {
+          collectionFilters.duplicatesOnly = false;
+          if (dom.collectionDuplicatesToggle) {
+            dom.collectionDuplicatesToggle.checked = false;
+          }
+        }
+        renderCollectionGallery();
+      });
+    }
+
+    if (dom.collectionDuplicatesToggle) {
+      dom.collectionDuplicatesToggle.checked = collectionFilters.duplicatesOnly;
+      dom.collectionDuplicatesToggle.addEventListener("change", (event) => {
+        collectionFilters.duplicatesOnly = Boolean(event.target.checked);
+        if (collectionFilters.duplicatesOnly && !collectionFilters.ownedOnly) {
+          collectionFilters.ownedOnly = true;
+          if (dom.collectionOwnedToggle) {
+            dom.collectionOwnedToggle.checked = true;
+          }
+        }
+        renderCollectionGallery();
+      });
+    }
+
+    renderCollectionGallery();
+  }
+
+  function renderCollectionGallery() {
+    if (!dom.collectionCards) {
+      return;
+    }
+
+    const itemCounts = collectionState.items ?? {};
+    const searchTerm = collectionFilters.search.trim().toLowerCase();
+    const hasOwnedCards = Object.values(itemCounts).some((count) => count > 0);
+    const entries = [];
+
+    allItems.forEach((item) => {
+      const owned = Math.max(0, Math.floor(Number(itemCounts[item.id]) || 0));
+      if (collectionFilters.setId !== "all" && item.setId !== collectionFilters.setId) {
+        return;
+      }
+      if (collectionFilters.rarity !== "all" && item.rarity !== collectionFilters.rarity) {
+        return;
+      }
+      if (collectionFilters.ownedOnly && owned <= 0) {
+        return;
+      }
+      if (collectionFilters.duplicatesOnly && owned <= 1) {
+        return;
+      }
+      if (searchTerm.length > 0) {
+        const set = setsById.get(item.setId);
+        const haystack = [item.name, item.text, set?.name, rarityLabels[item.rarity]]
+          .filter(Boolean)
+          .join(" ")
+          .toLowerCase();
+        if (!haystack.includes(searchTerm)) {
+          return;
+        }
+      }
+      entries.push({ item, owned });
+    });
+
+    sortCollectionEntries(entries);
+
+    dom.collectionCards.innerHTML = "";
+    const visibleEntries = [];
+
+    entries.forEach((entry) => {
+      const card = createCardElement(entry.item, { quantity: entry.owned });
+      if (entry.owned <= 0) {
+        card.classList.add("is-unowned");
+        appendCardBadge(card, "missing", "Fehlt");
+      } else if (entry.owned > 1) {
+        appendCardBadge(card, "duplicate", `Duplikate ×${entry.owned - 1}`);
+      }
+      dom.collectionCards.append(card);
+      visibleEntries.push(entry);
+    });
+
+    updateCollectionFilterSummary(visibleEntries);
+
+    if (dom.collectionEmpty) {
+      if (visibleEntries.length === 0) {
+        let message;
+        if (collectionFilters.duplicatesOnly) {
+          message = "Keine Duplikate entsprechen deiner Auswahl.";
+        } else if (collectionFilters.ownedOnly) {
+          message = hasOwnedCards
+            ? "Keine Karten in deiner Sammlung passen zu diesen Filtern."
+            : "Du besitzt noch keine Karten – öffne Booster oder sichere dir den Daily Bonus.";
+        } else {
+          message = "Keine Karten entsprechen deiner Auswahl.";
+        }
+        dom.collectionEmpty.textContent = message;
+        dom.collectionEmpty.hidden = false;
+      } else {
+        dom.collectionEmpty.hidden = true;
+      }
+    }
+  }
+
+  function sortCollectionEntries(entries) {
+    const mode = collectionFilters.sort;
+    entries.sort((a, b) => {
+      switch (mode) {
+        case "cost-asc": {
+          const costDiff = (a.item.cost ?? 0) - (b.item.cost ?? 0);
+          if (costDiff !== 0) {
+            return costDiff;
+          }
+          return a.item.name.localeCompare(b.item.name, "de");
+        }
+        case "cost-desc": {
+          const costDiff = (b.item.cost ?? 0) - (a.item.cost ?? 0);
+          if (costDiff !== 0) {
+            return costDiff;
+          }
+          return a.item.name.localeCompare(b.item.name, "de");
+        }
+        case "name-asc":
+          return a.item.name.localeCompare(b.item.name, "de");
+        case "set-asc": {
+          const setDiff = getSetOrderValue(a.item.setId) - getSetOrderValue(b.item.setId);
+          if (setDiff !== 0) {
+            return setDiff;
+          }
+          const rarityDiff = (rarityScore[b.item.rarity] ?? 0) - (rarityScore[a.item.rarity] ?? 0);
+          if (rarityDiff !== 0) {
+            return rarityDiff;
+          }
+          return a.item.name.localeCompare(b.item.name, "de");
+        }
+        case "rarity-desc":
+        default: {
+          const rarityDiff = (rarityScore[b.item.rarity] ?? 0) - (rarityScore[a.item.rarity] ?? 0);
+          if (rarityDiff !== 0) {
+            return rarityDiff;
+          }
+          const costDiff = (a.item.cost ?? 0) - (b.item.cost ?? 0);
+          if (costDiff !== 0) {
+            return costDiff;
+          }
+          return a.item.name.localeCompare(b.item.name, "de");
+        }
+      }
+    });
+  }
+
+  function updateCollectionFilterSummary(entries) {
+    if (!dom.collectionFilterSummary) {
+      return;
+    }
+
+    if (!entries || entries.length === 0) {
+      if (collectionFilters.duplicatesOnly) {
+        dom.collectionFilterSummary.textContent = "Keine Duplikate entsprechen deiner Auswahl.";
+      } else if (collectionFilters.ownedOnly) {
+        dom.collectionFilterSummary.textContent = "Keine Karten in deiner Sammlung passen zu diesen Filtern.";
+      } else {
+        dom.collectionFilterSummary.textContent = "Keine Karten entsprechen deiner Auswahl.";
+      }
+      return;
+    }
+
+    const infoParts = [`${entries.length} Karten`];
+    const ownedEntries = entries.filter((entry) => entry.owned > 0);
+    const ownedCopies = ownedEntries.reduce((sum, entry) => sum + entry.owned, 0);
+    const totalCopies = entries.reduce((sum, entry) => sum + Math.max(0, entry.owned), 0);
+
+    if (collectionFilters.ownedOnly) {
+      if (totalCopies > entries.length) {
+        infoParts.push(`${totalCopies} Kopien`);
+      }
+    } else {
+      infoParts.push(`${ownedEntries.length} Karten im Besitz`);
+      if (ownedCopies > 0) {
+        infoParts.push(`${ownedCopies} Kopien`);
+      }
+    }
+
+    if (collectionFilters.duplicatesOnly) {
+      infoParts.push("nur Duplikate");
+    }
+    if (!collectionFilters.ownedOnly) {
+      infoParts.push("inkl. fehlende Karten");
+    }
+
+    const filterParts = [];
+    if (collectionFilters.setId !== "all") {
+      const set = setsById.get(collectionFilters.setId);
+      filterParts.push(`Set: ${set?.name ?? collectionFilters.setId}`);
+    }
+    if (collectionFilters.rarity !== "all") {
+      filterParts.push(`Seltenheit: ${rarityLabels[collectionFilters.rarity] ?? collectionFilters.rarity}`);
+    }
+    const rawSearch = collectionFilters.search.trim();
+    if (rawSearch.length > 0) {
+      filterParts.push(`Suche "${rawSearch}"`);
+    }
+
+    let summary = `Angezeigt: ${infoParts.join(" · ")}`;
+    if (filterParts.length > 0) {
+      summary += ` (${filterParts.join(" · ")})`;
+    }
+    dom.collectionFilterSummary.textContent = summary;
+  }
+
+  function appendCardBadge(card, className, label) {
+    if (!card) {
+      return;
+    }
+    const content = card.querySelector(".card-content");
+    if (!content) {
+      return;
+    }
+    let flags = content.querySelector(".card-flags");
+    if (!flags) {
+      flags = document.createElement("div");
+      flags.className = "card-flags";
+      content.append(flags);
+    }
+    const tag = document.createElement("span");
+    tag.className = `tag ${className}`;
+    tag.textContent = label;
+    flags.append(tag);
+  }
+
+  function setupDeckBuilder() {
+    if (!dom.deckBuilderSection) {
+      return;
+    }
+    if (dom.deckBuilderName) {
+      dom.deckBuilderName.value = deckBuilderState.name ?? "";
+      dom.deckBuilderName.addEventListener("input", (event) => {
+        const value = typeof event.target.value === "string" ? event.target.value : "";
+        deckBuilderState.name = value;
+        markDeckBuilderChanged();
+        renderDeckBuilder();
+      });
+    }
+    if (dom.deckBuilderSave) {
+      dom.deckBuilderSave.addEventListener("click", handleDeckSave);
+    }
+    if (dom.deckBuilderReset) {
+      dom.deckBuilderReset.addEventListener("click", handleDeckReset);
+    }
+    renderDeckBuilder();
+  }
+
+  function handleDeckSave() {
+    const sanitizedName = sanitizeDeckName(deckBuilderState.name);
+    const sanitizedCards = sanitizeWorkingDeck(deckBuilderState.workingCards);
+    collectionState.deck.name = sanitizedName;
+    collectionState.deck.cards = sanitizedCards;
+    deckBuilderState.name = sanitizedName;
+    deckBuilderState.workingCards = cloneDeckCards(sanitizedCards);
+    deckBuilderState.status = { text: "Deck gespeichert.", tone: "success" };
+    updateDeckBuilderDirtyState();
+    saveCollection();
+    if (duelState.status === "idle") {
+      duelState.players = duelDefaultNames.map((playerName) => createIdlePlayerState(playerName));
+    }
+    renderDeckBuilder();
+    renderDeckList();
+  }
+
+  function handleDeckReset() {
+    deckBuilderState.name = collectionState.deck?.name ?? "Arena-Starter";
+    deckBuilderState.workingCards = cloneDeckCards(collectionState.deck?.cards ?? {});
+    deckBuilderState.status = { text: "Änderungen verworfen.", tone: "info" };
+    updateDeckBuilderDirtyState();
+    renderDeckBuilder();
+  }
+
+  function renderDeckBuilder() {
+    if (!dom.deckBuilderSection) {
+      return;
+    }
+    const total = getWorkingDeckTotal();
+    const missing = Math.max(0, duelConfig.deckSize - total);
+    if (dom.deckBuilderCount) {
+      dom.deckBuilderCount.textContent =
+        missing > 0
+          ? `${total}/${duelConfig.deckSize} Karten – es fehlen ${missing}`
+          : `${total}/${duelConfig.deckSize} Karten`;
+      dom.deckBuilderCount.classList.toggle("is-complete", total > 0 && missing === 0);
+    }
+    if (dom.deckBuilderName && document.activeElement !== dom.deckBuilderName) {
+      dom.deckBuilderName.value = deckBuilderState.name ?? "";
+    }
+    if (dom.deckBuilderSave) {
+      dom.deckBuilderSave.disabled = !deckBuilderState.dirty;
+    }
+    if (dom.deckBuilderReset) {
+      dom.deckBuilderReset.disabled = !deckBuilderState.dirty;
+    }
+    if (dom.deckBuilderStatus) {
+      if (deckBuilderState.status && deckBuilderState.status.text) {
+        dom.deckBuilderStatus.textContent = deckBuilderState.status.text;
+        dom.deckBuilderStatus.dataset.tone = deckBuilderState.status.tone ?? "info";
+      } else if (deckBuilderState.dirty) {
+        dom.deckBuilderStatus.textContent =
+          "Änderungen nicht gespeichert – speichere, um sie in der Arena zu verwenden.";
+        dom.deckBuilderStatus.dataset.tone = "warn";
+      } else {
+        const activeName = sanitizeDeckName(collectionState.deck?.name ?? deckBuilderState.name ?? "Arena-Starter");
+        dom.deckBuilderStatus.textContent = `Aktives Arena-Deck: „${activeName}“`;
+        dom.deckBuilderStatus.dataset.tone = "info";
+      }
+    }
+    renderDeckBuilderPool(total);
+    renderDeckBuilderSelection(total);
+  }
+
+  function renderDeckBuilderPool(total) {
+    if (!dom.deckBuilderPool) {
+      return;
+    }
+    const itemCounts = collectionState.items ?? {};
+    const entries = allItems
+      .map((item) => {
+        const owned = Math.max(0, Math.floor(Number(itemCounts[item.id]) || 0));
+        if (owned <= 0) {
+          return undefined;
+        }
+        const inDeck = Math.max(0, Math.floor(Number(deckBuilderState.workingCards[item.id]) || 0));
+        return { item, owned, inDeck };
+      })
+      .filter(Boolean);
+    entries.sort((a, b) => {
+      const setDiff = getSetOrderValue(a.item.setId) - getSetOrderValue(b.item.setId);
+      if (setDiff !== 0) {
+        return setDiff;
+      }
+      const rarityDiff = (rarityScore[b.item.rarity] ?? 0) - (rarityScore[a.item.rarity] ?? 0);
+      if (rarityDiff !== 0) {
+        return rarityDiff;
+      }
+      return a.item.name.localeCompare(b.item.name, "de");
+    });
+    dom.deckBuilderPool.innerHTML = "";
+    if (entries.length === 0) {
+      const message = document.createElement("p");
+      message.className = "deckbuilder-empty";
+      message.textContent = "Öffne Booster oder sichere dir den Daily Bonus, um neue Karten zu erhalten.";
+      dom.deckBuilderPool.append(message);
+      teardownDeckbuilderCarousel(dom.deckBuilderPool);
+      return;
+    }
+    entries.forEach((entry) => {
+      const card = createDeckBuilderPoolCard(entry, total);
+      dom.deckBuilderPool.append(card);
+    });
+    ensureDeckbuilderCarousel(dom.deckBuilderPool, deckbuilderCarouselPresets.pool);
+  }
+
+  function renderDeckBuilderSelection(total) {
+    if (!dom.deckBuilderSelection) {
+      return;
+    }
+    const itemCounts = collectionState.items ?? {};
+    const entries = Object.entries(deckBuilderState.workingCards ?? {})
+      .map(([cardId, value]) => {
+        const count = Math.max(0, Math.floor(Number(value) || 0));
+        if (count <= 0) {
+          return undefined;
+        }
+        const item = itemsById.get(cardId);
+        if (!item) {
+          return undefined;
+        }
+        const owned = Math.max(0, Math.floor(Number(itemCounts[cardId]) || 0));
+        return { item, count, owned };
+      })
+      .filter(Boolean);
+    entries.sort((a, b) => {
+      const costDiff = (a.item.cost ?? 0) - (b.item.cost ?? 0);
+      if (costDiff !== 0) {
+        return costDiff;
+      }
+      const setDiff = getSetOrderValue(a.item.setId) - getSetOrderValue(b.item.setId);
+      if (setDiff !== 0) {
+        return setDiff;
+      }
+      return a.item.name.localeCompare(b.item.name, "de");
+    });
+    dom.deckBuilderSelection.innerHTML = "";
+    if (entries.length === 0) {
+      const placeholder = document.createElement("p");
+      placeholder.className = "deckbuilder-empty";
+      placeholder.textContent = "Wähle Karten aus deiner Sammlung, um dein Arena-Deck zusammenzustellen.";
+      dom.deckBuilderSelection.append(placeholder);
+      teardownDeckbuilderCarousel(dom.deckBuilderSelection);
+      return;
+    }
+    const missing = Math.max(0, duelConfig.deckSize - total);
+    const note = document.createElement("p");
+    note.className = "deckbuilder-note";
+    if (missing > 0) {
+      note.classList.add("is-warning");
+      note.textContent =
+        missing === 1
+          ? "Es fehlt noch 1 Karte, um die 30 zu erreichen."
+          : `Es fehlen noch ${missing} Karten, um die 30 zu erreichen.`;
+    } else {
+      note.classList.add("is-success");
+      note.textContent = "Deckgröße erreicht – bereit für die Arena!";
+    }
+    dom.deckBuilderSelection.append(note);
+    entries.forEach((entry) => {
+      const card = createDeckBuilderSelectionCard(entry, total);
+      dom.deckBuilderSelection.append(card);
+    });
+    ensureDeckbuilderCarousel(dom.deckBuilderSelection, deckbuilderCarouselPresets.selection);
+  }
+
+  function createDeckBuilderBaseCard(item) {
+    const element = document.createElement("li");
+    element.className = "deckbuilder-card";
+    element.classList.add(`rarity-${item.rarity}`);
+    const artUri = getCardArtUri(item);
+    if (usesFullCardArtwork(item)) {
+      element.classList.add("deckbuilder-card--full-art");
+      const figure = document.createElement("figure");
+      figure.className = "deckbuilder-card-full-art";
+      const img = document.createElement("img");
+      img.src = artUri;
+      img.alt = `Illustration von ${item.name}`;
+      img.loading = "lazy";
+      figure.append(img);
+      const caption = document.createElement("figcaption");
+      caption.className = "sr-only";
+      caption.textContent = item.name;
+      figure.append(caption);
+      element.append(figure);
+      const srText = createSrOnlyText(getCardAccessibilitySummary(item, 0, buildCardMeta(item)));
+      if (srText) {
+        element.append(srText);
+      }
+      const footer = document.createElement("footer");
+      footer.className = "deckbuilder-card-footer";
+      element.append(footer);
+      const countLabel = document.createElement("span");
+      countLabel.className = "deckbuilder-card-count";
+      footer.append(countLabel);
+      const controls = document.createElement("div");
+      controls.className = "deckbuilder-card-controls";
+      footer.append(controls);
+      return { root: element, countLabel, controls };
+    }
+    const art = document.createElement("figure");
+    art.className = "deckbuilder-card-art";
+    const img = document.createElement("img");
+    img.src = artUri;
+    img.alt = `Illustration von ${item.name}`;
+    img.loading = "lazy";
+    art.append(img);
+    element.append(art);
+    const info = document.createElement("div");
+    info.className = "deckbuilder-card-info";
+    element.append(info);
+    const header = document.createElement("header");
+    const title = document.createElement("strong");
+    title.textContent = item.name;
+    const rarity = document.createElement("span");
+    rarity.className = "deckbuilder-card-rarity";
+    rarity.textContent = rarityLabels[item.rarity] ?? item.rarity;
+    header.append(title, rarity);
+    info.append(header);
+    const type = document.createElement("p");
+    type.className = "deckbuilder-card-type";
+    type.textContent = getDeckbuilderMetaLabel(item);
+    info.append(type);
+    const stats = document.createElement("div");
+    stats.className = "deckbuilder-card-stats";
+    stats.setAttribute("role", "group");
+    stats.setAttribute("aria-label", "Kartenwerte");
+    const damageValue =
+      item.cardType === "spell" ? (item.damage > 0 ? String(item.damage) : "–") : String(item.damage);
+    const healthValue = item.cardType === "spell" ? "–" : String(item.health);
+    stats.append(
+      createDeckbuilderStat(statIcons.cost, String(item.cost), "Kosten"),
+      createDeckbuilderStat(statIcons.damage, damageValue, item.cardType === "spell" ? "Zauberschaden" : "Angriff"),
+      createDeckbuilderStat(statIcons.health, healthValue, item.cardType === "spell" ? "Zauberschutz" : "Lebenspunkte")
+    );
+    info.append(stats);
+    const footer = document.createElement("footer");
+    footer.className = "deckbuilder-card-footer";
+    info.append(footer);
+    const countLabel = document.createElement("span");
+    countLabel.className = "deckbuilder-card-count";
+    footer.append(countLabel);
+    const controls = document.createElement("div");
+    controls.className = "deckbuilder-card-controls";
+    footer.append(controls);
+    return { root: element, countLabel, controls };
+  }
+
+  function createDeckBuilderPoolCard(entry, total) {
+    const { root, countLabel, controls } = createDeckBuilderBaseCard(entry.item);
+    const available = Math.max(0, entry.owned - entry.inDeck);
+    countLabel.textContent = `Besitz: ${entry.owned} · Frei: ${available}`;
+    if (available <= 0) {
+      root.classList.add("is-depleted");
+    }
+    if (total >= duelConfig.deckSize) {
+      root.classList.add("is-capped");
+    }
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "deckbuilder-button";
+    button.dataset.action = "add";
+    button.textContent = "Hinzufügen";
+    button.setAttribute("aria-label", `${entry.item.name} zum Deck hinzufügen`);
+    if (total >= duelConfig.deckSize) {
+      button.title = "Deckgröße erreicht";
+    }
+    if (available <= 0) {
+      button.title = "Keine weiteren Kopien verfügbar";
+    }
+    button.disabled = available <= 0 || total >= duelConfig.deckSize;
+    button.addEventListener("click", () => addCardToDeck(entry.item.id));
+    controls.append(button);
+    if (!controls.childElementCount) {
+      controls.remove();
+    }
+    return root;
+  }
+
+  function createDeckBuilderSelectionCard(entry, total) {
+    const { root, countLabel, controls } = createDeckBuilderBaseCard(entry.item);
+    countLabel.textContent = `Im Deck: ${entry.count} · Besitz: ${entry.owned}`;
+    const removeButton = document.createElement("button");
+    removeButton.type = "button";
+    removeButton.className = "deckbuilder-button";
+    removeButton.dataset.action = "remove";
+    removeButton.textContent = "−1";
+    removeButton.setAttribute("aria-label", `${entry.item.name} aus dem Deck entfernen`);
+    removeButton.disabled = entry.count <= 0;
+    removeButton.addEventListener("click", () => removeCardFromDeck(entry.item.id));
+    controls.append(removeButton);
+    const available = Math.max(0, entry.owned - entry.count);
+    const addButton = document.createElement("button");
+    addButton.type = "button";
+    addButton.className = "deckbuilder-button";
+    addButton.dataset.action = "add";
+    addButton.textContent = "+1";
+    addButton.setAttribute("aria-label", `Eine weitere Kopie von ${entry.item.name} hinzufügen`);
+    if (total >= duelConfig.deckSize) {
+      addButton.title = "Deckgröße erreicht";
+    } else if (available <= 0) {
+      addButton.title = "Keine weiteren Kopien in der Sammlung";
+    }
+    addButton.disabled = available <= 0 || total >= duelConfig.deckSize;
+    addButton.addEventListener("click", () => addCardToDeck(entry.item.id));
+    controls.append(addButton);
+    if (!controls.childElementCount) {
+      controls.remove();
+    }
+    return root;
+  }
+
+  function createDeckbuilderStat(iconMarkup, value, label) {
+    const chip = document.createElement("span");
+    chip.className = "deckbuilder-stat";
+    chip.setAttribute("aria-label", label);
+    chip.insertAdjacentHTML("beforeend", iconMarkup);
+    const strong = document.createElement("strong");
+    strong.textContent = value;
+    chip.append(strong);
+    return chip;
+  }
+
+  function ensureDeckbuilderCarousel(element, options = {}) {
+    if (!element) {
+      return;
+    }
+    const selector =
+      typeof options.itemSelector === "string" && options.itemSelector
+        ? options.itemSelector
+        : ".deckbuilder-card";
+    const hasCards = Boolean(element.querySelector(selector));
+    if (!hasCards) {
+      teardownDeckbuilderCarousel(element);
+      element.classList.add("is-empty");
+      element.classList.remove("is-at-start", "is-at-end");
+      return;
+    }
+    let controller = deckbuilderCarouselControllers.get(element);
+    if (!controller) {
+      controller = createDeckCarousel(element, options);
+      deckbuilderCarouselControllers.set(element, controller);
+    } else {
+      controller.configure(options);
+    }
+    controller.update();
+  }
+
+  function teardownDeckbuilderCarousel(element) {
+    if (!element) {
+      return;
+    }
+    const controller = deckbuilderCarouselControllers.get(element);
+    if (controller) {
+      controller.destroy();
+      deckbuilderCarouselControllers.delete(element);
+    }
+  }
+
+  function createDeckCarousel(element, initialOptions = {}) {
+    const config = {
+      itemSelector: ".deckbuilder-card",
+      baseScale: 1,
+      focusScale: 1,
+      maxTilt: 0,
+      friction: 0.003,
+      maxVelocity: 3,
+      allowMomentum: true,
+      lift: 0,
+      wheelFactor: 1,
+      enableFocus: true,
+      mode: "",
+    };
+    let currentMode = "";
+    let items = [];
+    let pointerActive = false;
+    let activePointerId;
+    let lastX = 0;
+    let lastTime = 0;
+    let pointerStartScroll = 0;
+    let velocity = 0;
+    let moved = false;
+    let momentumRaf = 0;
+    let focusRaf = 0;
+    let resizeObserver;
+
+    const controller = {
+      update: updateItems,
+      configure,
+      destroy,
+    };
+
+    configure(initialOptions);
+
+    if (typeof ResizeObserver !== "undefined") {
+      resizeObserver = new ResizeObserver(() => requestFocusUpdate(true));
+      resizeObserver.observe(element);
+    }
+
+    element.addEventListener("pointerdown", onPointerDown);
+    element.addEventListener("pointermove", onPointerMove);
+    element.addEventListener("pointerup", onPointerUp);
+    element.addEventListener("pointercancel", onPointerCancel);
+    element.addEventListener("scroll", onScroll, { passive: true });
+    element.addEventListener("wheel", onWheel, { passive: false });
+
+    updateItems();
+
+    return controller;
+
+    function configure(options = {}) {
+      if (!options || typeof options !== "object") {
+        options = {};
+      }
+      const prevMode = currentMode;
+      Object.entries(options).forEach(([key, value]) => {
+        if (value !== undefined) {
+          config[key] = value;
+        }
+      });
+      config.baseScale = toNumber(config.baseScale, 1);
+      config.focusScale = toNumber(config.focusScale, config.baseScale);
+      config.maxTilt = toNumber(config.maxTilt, 0);
+      config.friction = toNumber(config.friction, 0.003);
+      config.maxVelocity = Math.max(0, toNumber(config.maxVelocity, 3));
+      config.lift = Math.max(0, toNumber(config.lift, 0));
+      config.wheelFactor = toNumber(config.wheelFactor, 1);
+      if (options.allowMomentum !== undefined) {
+        config.allowMomentum = Boolean(options.allowMomentum);
+      }
+      if (options.enableFocus !== undefined) {
+        config.enableFocus = Boolean(options.enableFocus);
+      } else {
+        const hasAnimation =
+          Math.abs(config.focusScale - config.baseScale) > 0.001 ||
+          Math.abs(config.maxTilt) > 0.001 ||
+          Math.abs(config.lift) > 0.001;
+        config.enableFocus = hasAnimation;
+      }
+      config.itemSelector =
+        typeof config.itemSelector === "string" && config.itemSelector
+          ? config.itemSelector
+          : ".deckbuilder-card";
+      currentMode = typeof config.mode === "string" ? config.mode : "";
+      if (prevMode && prevMode !== currentMode) {
+        element.classList.remove(`carousel-mode-${prevMode}`);
+      }
+      if (currentMode) {
+        element.classList.add(`carousel-mode-${currentMode}`);
+        element.dataset.carouselMode = currentMode;
+      } else if (prevMode) {
+        element.classList.remove(`carousel-mode-${prevMode}`);
+        delete element.dataset.carouselMode;
+      } else {
+        delete element.dataset.carouselMode;
+      }
+    }
+
+    function updateItems() {
+      items = Array.from(element.querySelectorAll(config.itemSelector));
+      element.classList.toggle("is-empty", items.length === 0);
+      resetItemsToBase();
+      updateEdgeState();
+      if (items.length === 0) {
+        cancelMomentum();
+        return;
+      }
+      requestFocusUpdate(true);
+    }
+
+    function onPointerDown(event) {
+      if (!event.isPrimary) {
+        return;
+      }
+      if (event.pointerType === "mouse" && event.button !== 0) {
+        return;
+      }
+      if (event.target.closest("button, input, select, textarea, a")) {
+        return;
+      }
+      pointerActive = true;
+      activePointerId = event.pointerId;
+      pointerStartScroll = element.scrollLeft;
+      moved = false;
+      velocity = 0;
+      cancelMomentum();
+      lastX = event.clientX;
+      lastTime = performance.now();
+      element.classList.add("is-dragging");
+      updateEdgeState();
+      if (typeof element.setPointerCapture === "function") {
+        try {
+          element.setPointerCapture(activePointerId);
+        } catch (error) {
+          /* ignore */
+        }
+      }
+      event.preventDefault();
+    }
+
+    function onPointerMove(event) {
+      if (!pointerActive || event.pointerId !== activePointerId) {
+        return;
+      }
+      const now = performance.now();
+      const deltaX = event.clientX - lastX;
+      const dt = Math.max(now - lastTime, 1);
+      lastX = event.clientX;
+      lastTime = now;
+      element.scrollLeft -= deltaX;
+      const hitBoundary = clampScroll();
+      if (!moved && Math.abs(element.scrollLeft - pointerStartScroll) > 1) {
+        moved = true;
+      }
+      velocity = hitBoundary ? 0 : clampVelocity(deltaX / dt);
+      requestFocusUpdate();
+      event.preventDefault();
+    }
+
+    function onPointerUp(event) {
+      if (!pointerActive || event.pointerId !== activePointerId) {
+        return;
+      }
+      pointerActive = false;
+      releasePointer();
+      element.classList.remove("is-dragging");
+      if (moved) {
+        startMomentum(velocity);
+      } else {
+        velocity = 0;
+        requestFocusUpdate(true);
+        updateEdgeState();
+      }
+      activePointerId = undefined;
+    }
+
+    function onPointerCancel(event) {
+      if (!pointerActive || event.pointerId !== activePointerId) {
+        return;
+      }
+      pointerActive = false;
+      moved = false;
+      velocity = 0;
+      releasePointer();
+      element.classList.remove("is-dragging");
+      requestFocusUpdate(true);
+      updateEdgeState();
+      activePointerId = undefined;
+    }
+
+    function onScroll() {
+      if (pointerActive) {
+        return;
+      }
+      updateEdgeState();
+      requestFocusUpdate();
+    }
+
+    function onWheel(event) {
+      if (!items.length) {
+        return;
+      }
+      const factor = config.wheelFactor;
+      if (!Number.isFinite(factor) || factor === 0) {
+        return;
+      }
+      const primaryDelta =
+        Math.abs(event.deltaX) > Math.abs(event.deltaY) ? event.deltaX : event.deltaY;
+      if (!primaryDelta) {
+        return;
+      }
+      event.preventDefault();
+      cancelMomentum();
+      element.scrollLeft += primaryDelta * factor;
+      clampScroll();
+      requestFocusUpdate();
+    }
+
+    function startMomentum(initialVelocity) {
+      if (!config.allowMomentum) {
+        updateEdgeState();
+        requestFocusUpdate(true);
+        return;
+      }
+      let momentumVelocity = clampVelocity(initialVelocity);
+      if (!Number.isFinite(momentumVelocity) || Math.abs(momentumVelocity) < 0.01) {
+        updateEdgeState();
+        requestFocusUpdate(true);
+        return;
+      }
+      cancelMomentum();
+      let last = performance.now();
+      const step = (time) => {
+        const dt = time - last;
+        last = time;
+        element.scrollLeft -= momentumVelocity * dt;
+        const hitBoundary = clampScroll();
+        const friction = config.friction;
+        if (Number.isFinite(friction) && friction > 0) {
+          const reduction = friction * dt;
+          if (momentumVelocity > 0) {
+            momentumVelocity = Math.max(0, momentumVelocity - reduction);
+          } else if (momentumVelocity < 0) {
+            momentumVelocity = Math.min(0, momentumVelocity + reduction);
+          }
+        }
+        if (hitBoundary) {
+          momentumVelocity = 0;
+        }
+        requestFocusUpdate();
+        if (Math.abs(momentumVelocity) > 0.01) {
+          momentumRaf = window.requestAnimationFrame(step);
+        } else {
+          cancelMomentum();
+          updateEdgeState();
+          requestFocusUpdate(true);
+        }
+      };
+      momentumRaf = window.requestAnimationFrame(step);
+    }
+
+    function cancelMomentum() {
+      if (momentumRaf) {
+        window.cancelAnimationFrame(momentumRaf);
+        momentumRaf = 0;
+      }
+    }
+
+    function requestFocusUpdate(force = false) {
+      if (!force && !config.enableFocus) {
+        return;
+      }
+      if (focusRaf) {
+        return;
+      }
+      focusRaf = window.requestAnimationFrame(() => {
+        focusRaf = 0;
+        applyFocus(force);
+      });
+    }
+
+    function applyFocus(force = false) {
+      if (!items.length) {
+        return;
+      }
+      if (!config.enableFocus && !force) {
+        resetItemsToBase();
+        return;
+      }
+      const rect = element.getBoundingClientRect();
+      if (!rect || rect.width <= 0) {
+        resetItemsToBase();
+        return;
+      }
+      const center = rect.left + rect.width / 2;
+      const baseRange = rect.width / 2;
+      const baseScale = config.baseScale;
+      items.forEach((item) => {
+        if (!item.isConnected) {
+          return;
+        }
+        const cardRect = item.getBoundingClientRect();
+        if (!cardRect || cardRect.width <= 0) {
+          item.style.setProperty("--carousel-scale", baseScale.toFixed(3));
+          item.style.setProperty("--carousel-focus", "0");
+          item.style.setProperty("--carousel-tilt", "0deg");
+          item.style.setProperty("--carousel-shift", "0px");
+          item.style.setProperty("--carousel-z", "1");
+          return;
+        }
+        const itemCenter = cardRect.left + cardRect.width / 2;
+        const range = baseRange + cardRect.width;
+        const distance = Math.abs(center - itemCenter);
+        const focusRatio = range > 0 ? Math.max(0, Math.min(1, 1 - distance / range)) : 0;
+        const scale = baseScale + (config.focusScale - baseScale) * focusRatio;
+        const direction = itemCenter >= center ? 1 : -1;
+        const tilt = (config.maxTilt || 0) * focusRatio * direction;
+        const lift = (config.lift || 0) * focusRatio;
+        item.style.setProperty("--carousel-scale", scale.toFixed(3));
+        item.style.setProperty("--carousel-focus", focusRatio.toFixed(3));
+        item.style.setProperty("--carousel-tilt", `${tilt.toFixed(2)}deg`);
+        item.style.setProperty("--carousel-shift", `${lift.toFixed(2)}px`);
+        item.style.setProperty("--carousel-z", String(100 + Math.round(focusRatio * 100)));
+      });
+    }
+
+    function resetItemsToBase() {
+      const base = config.baseScale;
+      const baseValue = Number.isFinite(base) ? base : 1;
+      items.forEach((item) => {
+        item.style.setProperty("--carousel-scale", baseValue.toFixed(3));
+        item.style.setProperty("--carousel-focus", "0");
+        item.style.setProperty("--carousel-tilt", "0deg");
+        item.style.setProperty("--carousel-shift", "0px");
+        item.style.setProperty("--carousel-z", "1");
+      });
+    }
+
+    function clampScroll() {
+      const max = Math.max(0, element.scrollWidth - element.clientWidth);
+      let clamped = false;
+      if (max <= 0) {
+        if (element.scrollLeft !== 0) {
+          element.scrollLeft = 0;
+          clamped = true;
+        }
+      } else if (element.scrollLeft < 0) {
+        element.scrollLeft = 0;
+        clamped = true;
+      } else if (element.scrollLeft > max) {
+        element.scrollLeft = max;
+        clamped = true;
+      }
+      updateEdgeState();
+      return clamped || max <= 0;
+    }
+
+    function updateEdgeState() {
+      const max = Math.max(0, element.scrollWidth - element.clientWidth);
+      const atStart = max <= 1 || element.scrollLeft <= 1;
+      const atEnd = max <= 1 || element.scrollLeft >= max - 1;
+      element.classList.toggle("is-at-start", atStart);
+      element.classList.toggle("is-at-end", atEnd);
+    }
+
+    function clampVelocity(value) {
+      if (!Number.isFinite(value)) {
+        return 0;
+      }
+      const limit = Number(config.maxVelocity);
+      if (!Number.isFinite(limit) || limit <= 0) {
+        return value;
+      }
+      return Math.max(-limit, Math.min(limit, value));
+    }
+
+    function releasePointer() {
+      if (
+        typeof activePointerId !== "number" ||
+        typeof element.releasePointerCapture !== "function"
+      ) {
+        return;
+      }
+      if (typeof element.hasPointerCapture === "function") {
+        try {
+          if (!element.hasPointerCapture(activePointerId)) {
+            return;
+          }
+        } catch (error) {
+          return;
+        }
+      }
+      try {
+        element.releasePointerCapture(activePointerId);
+      } catch (error) {
+        /* ignore */
+      }
+    }
+
+    function destroy() {
+      cancelMomentum();
+      if (focusRaf) {
+        window.cancelAnimationFrame(focusRaf);
+        focusRaf = 0;
+      }
+      pointerActive = false;
+      activePointerId = undefined;
+      element.classList.remove("is-dragging", "is-empty", "is-at-start", "is-at-end");
+      if (currentMode) {
+        element.classList.remove(`carousel-mode-${currentMode}`);
+      }
+      delete element.dataset.carouselMode;
+      element.removeEventListener("pointerdown", onPointerDown);
+      element.removeEventListener("pointermove", onPointerMove);
+      element.removeEventListener("pointerup", onPointerUp);
+      element.removeEventListener("pointercancel", onPointerCancel);
+      element.removeEventListener("scroll", onScroll);
+      element.removeEventListener("wheel", onWheel);
+      if (resizeObserver) {
+        try {
+          resizeObserver.disconnect();
+        } catch (error) {
+          /* ignore */
+        }
+      }
+      items.forEach((item) => {
+        item.style.removeProperty("--carousel-scale");
+        item.style.removeProperty("--carousel-focus");
+        item.style.removeProperty("--carousel-tilt");
+        item.style.removeProperty("--carousel-shift");
+        item.style.removeProperty("--carousel-z");
+      });
+      items = [];
+    }
+
+    function toNumber(value, fallback) {
+      const parsed = Number(value);
+      return Number.isFinite(parsed) ? parsed : fallback;
+    }
+  }
+
+  function getDeckbuilderMetaLabel(item) {
+    const set = setsById.get(item.setId);
+    const parts = [];
+    if (set?.name) {
+      parts.push(set.name);
+    }
+    if (item.cardType === "spell") {
+      parts.push("Zauber");
+    } else {
+      parts.push("Einheit");
+      if (Array.isArray(item.abilities) && item.abilities.includes("bulwark")) {
+        parts.push("Bollwerk");
+      }
+    }
+    return parts.join(" · ");
+  }
+
+  function addCardToDeck(cardId) {
+    if (!cardId) {
+      return;
+    }
+    const ownedCount = Math.max(0, Math.floor(Number((collectionState.items ?? {})[cardId]) || 0));
+    if (ownedCount <= 0) {
+      return;
+    }
+    const current = Math.max(0, Math.floor(Number(deckBuilderState.workingCards?.[cardId]) || 0));
+    if (current >= ownedCount) {
+      return;
+    }
+    if (getWorkingDeckTotal() >= duelConfig.deckSize) {
+      return;
+    }
+    deckBuilderState.workingCards[cardId] = current + 1;
+    markDeckBuilderChanged();
+    renderDeckBuilder();
+  }
+
+  function removeCardFromDeck(cardId) {
+    if (!cardId) {
+      return;
+    }
+    const current = Math.max(0, Math.floor(Number(deckBuilderState.workingCards?.[cardId]) || 0));
+    if (current <= 0) {
+      return;
+    }
+    if (current <= 1) {
+      delete deckBuilderState.workingCards[cardId];
+    } else {
+      deckBuilderState.workingCards[cardId] = current - 1;
+    }
+    markDeckBuilderChanged();
+    renderDeckBuilder();
+  }
+
+  function getWorkingDeckTotal() {
+    const cards = deckBuilderState.workingCards ?? {};
+    return Object.values(cards).reduce((sum, value) => sum + Math.max(0, Math.floor(Number(value) || 0)), 0);
+  }
+
+  function markDeckBuilderChanged() {
+    const wasDirty = deckBuilderState.dirty;
+    updateDeckBuilderDirtyState();
+    if (!wasDirty && deckBuilderState.dirty) {
+      deckBuilderState.status = undefined;
+    }
+  }
+
+  function updateDeckBuilderDirtyState() {
+    const savedDeck = collectionState.deck ?? { name: "", cards: {} };
+    const savedName = sanitizeDeckName(savedDeck.name ?? "");
+    const currentName = sanitizeDeckName(deckBuilderState.name ?? "");
+    if (savedName !== currentName) {
+      deckBuilderState.dirty = true;
+      return;
+    }
+    const savedEntries = Object.entries(savedDeck.cards ?? {})
+      .map(([cardId, count]) => [cardId, Math.max(0, Math.floor(Number(count) || 0))])
+      .filter(([, count]) => count > 0)
+      .sort(([a], [b]) => a.localeCompare(b));
+    const workingEntries = Object.entries(deckBuilderState.workingCards ?? {})
+      .map(([cardId, count]) => [cardId, Math.max(0, Math.floor(Number(count) || 0))])
+      .filter(([, count]) => count > 0)
+      .sort(([a], [b]) => a.localeCompare(b));
+    if (savedEntries.length !== workingEntries.length) {
+      deckBuilderState.dirty = true;
+      return;
+    }
+    const changed = savedEntries.some(([cardId, count], index) => {
+      const [otherId, otherCount] = workingEntries[index];
+      return cardId !== otherId || count !== otherCount;
+    });
+    deckBuilderState.dirty = changed;
+  }
+
+  function sanitizeDeckName(value) {
+    if (typeof value !== "string") {
+      return "Arena-Starter";
+    }
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      return "Arena-Starter";
+    }
+    if (trimmed.length > 40) {
+      return trimmed.slice(0, 40);
+    }
+    return trimmed;
+  }
+
+  function cloneDeckCards(cards) {
+    const copy = {};
+    if (!cards || typeof cards !== "object") {
+      return copy;
+    }
+    Object.entries(cards).forEach(([cardId, value]) => {
+      const count = Math.max(0, Math.floor(Number(value) || 0));
+      if (count > 0) {
+        copy[cardId] = count;
+      }
+    });
+    return copy;
+  }
+
+  function clampDeckToOwned(deck) {
+    if (!deck || typeof deck !== "object") {
+      return false;
+    }
+    if (!deck.cards || typeof deck.cards !== "object") {
+      deck.cards = {};
+      return true;
+    }
+    const owned = collectionState.items ?? {};
+    const normalized = [];
+    Object.entries(deck.cards).forEach(([cardId, value]) => {
+      const item = itemsById.get(cardId);
+      if (!item) {
+        return;
+      }
+      const desired = Math.max(0, Math.floor(Number(value) || 0));
+      if (desired <= 0) {
+        return;
+      }
+      const ownedCount = Math.max(0, Math.floor(Number(owned[cardId]) || 0));
+      if (ownedCount <= 0) {
+        return;
+      }
+      const allowed = Math.min(desired, ownedCount);
+      normalized.push({ cardId, count: allowed, item });
+    });
+    normalized.sort((a, b) => {
+      const rarityDiff = (rarityScore[b.item.rarity] ?? 0) - (rarityScore[a.item.rarity] ?? 0);
+      if (rarityDiff !== 0) {
+        return rarityDiff;
+      }
+      const setDiff = getSetOrderValue(a.item.setId) - getSetOrderValue(b.item.setId);
+      if (setDiff !== 0) {
+        return setDiff;
+      }
+      return a.item.name.localeCompare(b.item.name, "de");
+    });
+    const trimmed = {};
+    let remaining = duelConfig.deckSize;
+    normalized.forEach((entry) => {
+      if (remaining <= 0) {
+        return;
+      }
+      const allowed = Math.min(entry.count, remaining);
+      if (allowed > 0) {
+        trimmed[entry.cardId] = allowed;
+        remaining -= allowed;
+      }
+    });
+    const originalKeys = Object.keys(deck.cards);
+    const trimmedKeys = Object.keys(trimmed);
+    let changed = originalKeys.length !== trimmedKeys.length;
+    if (!changed) {
+      for (let i = 0; i < trimmedKeys.length; i += 1) {
+        const key = trimmedKeys[i];
+        if (deck.cards[key] !== trimmed[key]) {
+          changed = true;
+          break;
+        }
+      }
+    }
+    deck.cards = trimmed;
+    return changed;
+  }
+
+  function generateDefaultDeckFromCollection() {
+    const owned = collectionState.items ?? {};
+    const pool = [];
+    Object.entries(owned).forEach(([cardId, value]) => {
+      const item = itemsById.get(cardId);
+      if (!item) {
+        return;
+      }
+      const count = Math.max(0, Math.floor(Number(value) || 0));
+      for (let i = 0; i < count; i += 1) {
+        pool.push(cardId);
+      }
+    });
+    if (pool.length === 0) {
+      return { name: "Arena-Starter", cards: {} };
+    }
+    const selection = shuffle(pool).slice(0, duelConfig.deckSize);
+    const cards = {};
+    selection.forEach((cardId) => {
+      cards[cardId] = (cards[cardId] ?? 0) + 1;
+    });
+    return { name: "Arena-Starter", cards };
+  }
+
+  function sanitizeWorkingDeck(source) {
+    const deck = { cards: cloneDeckCards(source) };
+    clampDeckToOwned(deck);
+    return deck.cards;
+  }
+
+  function getActiveDeckCardList() {
+    const deck = collectionState.deck;
+    if (!deck || !deck.cards || typeof deck.cards !== "object") {
+      return [];
+    }
+    const entries = Object.entries(deck.cards)
+      .map(([cardId, value]) => {
+        const count = Math.max(0, Math.floor(Number(value) || 0));
+        const item = itemsById.get(cardId);
+        if (!item || count <= 0) {
+          return undefined;
+        }
+        return { cardId, count, item };
+      })
+      .filter(Boolean);
+    entries.sort((a, b) => {
+      const costDiff = (a.item.cost ?? 0) - (b.item.cost ?? 0);
+      if (costDiff !== 0) {
+        return costDiff;
+      }
+      const rarityDiff = (rarityScore[b.item.rarity] ?? 0) - (rarityScore[a.item.rarity] ?? 0);
+      if (rarityDiff !== 0) {
+        return rarityDiff;
+      }
+      return a.item.name.localeCompare(b.item.name, "de");
+    });
+    const cards = [];
+    entries.forEach((entry) => {
+      for (let i = 0; i < entry.count; i += 1) {
+        cards.push(entry.cardId);
+      }
+    });
+    return cards;
+  }
+
+  function getSetOrderValue(setId) {
+    if (setOrder.has(setId)) {
+      return setOrder.get(setId);
+    }
+    return Number.MAX_SAFE_INTEGER;
+  }
+
+  function ensureCollectionStructure() {
+    let mutated = false;
+    if (!collectionState || typeof collectionState !== "object") {
+      collectionState = { items: {} };
+      mutated = true;
+    }
+    if (!collectionState.items || typeof collectionState.items !== "object") {
+      collectionState.items = {};
+      mutated = true;
+    }
+    if (!collectionState.deck || typeof collectionState.deck !== "object") {
+      collectionState.deck = generateDefaultDeckFromCollection();
+      mutated = true;
+    }
+    if (!collectionState.deck.cards || typeof collectionState.deck.cards !== "object") {
+      collectionState.deck.cards = {};
+      mutated = true;
+    }
+    const sanitizedName = sanitizeDeckName(collectionState.deck.name);
+    if (collectionState.deck.name !== sanitizedName) {
+      collectionState.deck.name = sanitizedName;
+      mutated = true;
+    }
+    const adjusted = clampDeckToOwned(collectionState.deck);
+    if (adjusted) {
+      mutated = true;
+    }
+    return mutated;
+  }
+
+  function updateCollectionUI() {
+    const itemCounts = collectionState.items ?? {};
+    const allOwned = Object.values(itemCounts).reduce((total, count) => total + count, 0);
+    dom.totalOwned.textContent = allOwned;
+
+    const uniqueOwned = Object.keys(itemCounts).filter((itemId) => itemCounts[itemId] > 0).length;
+    dom.uniqueOwned.textContent = uniqueOwned;
+
+    let completed = 0;
+    let activeSets = 0;
+
+    sets.forEach((set) => {
+      const setCard = dom.collectionGrid.querySelector(`[data-set-id="${set.id}"]`);
+      if (!setCard) {
+        return;
+      }
+      const setItems = allItems.filter((item) => item.setId === set.id);
+      const ownedUnique = setItems.filter((item) => itemCounts[item.id] > 0);
+      const progress = ownedUnique.length / set.total;
+      const bar = setCard.querySelector(".progress-bar span");
+      const progressBar = setCard.querySelector(".progress-bar");
+      const count = setCard.querySelector(".progress-count");
+      if (bar) {
+        bar.style.width = `${Math.floor(progress * 100)}%`;
+      }
+      if (count) {
+        count.textContent = `${ownedUnique.length} / ${set.total}`;
+      }
+      if (progressBar) {
+        progressBar.setAttribute("aria-valuenow", ownedUnique.length);
+        progressBar.setAttribute("aria-valuetext", `${ownedUnique.length} von ${set.total}`);
+      }
+      setCard.classList.toggle("completed", ownedUnique.length >= set.total);
+      if (ownedUnique.length > 0) {
+        activeSets += 1;
+      }
+      if (ownedUnique.length >= set.total) {
+        completed += 1;
+      }
+    });
+
+    dom.completedSets.textContent = completed;
+    dom.activeSetCount.textContent = activeSets;
+
+    updateTradeHub(itemCounts);
+    renderDeckBuilder();
+    renderCollectionGallery();
+  }
+
+  function updateTradeHub(itemCounts) {
+    dom.tradeList.innerHTML = "";
+    const duplicates = Object.entries(itemCounts)
+      .filter(([, count]) => count > 1)
+      .map(([itemId, count]) => ({ item: itemsById.get(itemId), count }));
+    if (duplicates.length === 0) {
+      const note = document.createElement("li");
+      note.textContent = "Noch keine Duplikate – öffne mehr Booster!";
+      dom.tradeList.append(note);
+      return;
+    }
+
+    const missingItems = allItems.filter((item) => !itemCounts[item.id]);
+    duplicates.slice(0, 4).forEach(({ item, count }) => {
+      if (!item) {
+        return;
+      }
+      const li = document.createElement("li");
+      const label = document.createElement("span");
+      label.textContent = `${item.name} ×${count}`;
+      li.append(label);
+      const wanted = missingItems.find((missing) => missing.setId === item.setId);
+      if (wanted) {
+        const wantedLabel = document.createElement("span");
+        wantedLabel.className = "wanted";
+        wantedLabel.textContent = `suche ${wanted.name}`;
+        li.append(wantedLabel);
+      }
+      dom.tradeList.append(li);
+    });
+  }
+
+  function claimDailyReward() {
+    if (!canClaimToday()) {
+      return;
+    }
+
+    const today = new Date();
+    const lastClaim = loginState.lastClaim ? new Date(loginState.lastClaim) : undefined;
+    const isConsecutive = lastClaim ? isNextDay(lastClaim, today) : false;
+
+    if (isConsecutive) {
+      loginState.streak += 1;
+    } else {
+      loginState.streak = 1;
+    }
+
+    loginState.lastClaim = today.toISOString();
+
+    const reward = grantDailyItem(loginState.streak);
+    addItemToCollection(reward.id, 1);
+    saveCollection();
+    saveLoginState();
+
+    showDailyReward(reward);
+    updateCollectionUI();
+    updateDailyLoginUI();
+    updateHeroStats();
+  }
+
+  function canClaimToday() {
+    if (!loginState.lastClaim) {
+      return true;
+    }
+    const lastClaim = new Date(loginState.lastClaim);
+    const today = new Date();
+    return !isSameDay(lastClaim, today);
+  }
+
+  function grantDailyItem(streak) {
+    let rewardRarity = "uncommon";
+    if (streak % 14 === 0) {
+      rewardRarity = "legendary";
+    } else if (streak % 7 === 0) {
+      rewardRarity = "epic";
+    } else if (streak % 3 === 0) {
+      rewardRarity = "rare";
+    }
+
+    const available = allItems.filter((item) => item.rarity === rewardRarity && !item.isLimited);
+    const choice = available[Math.floor(Math.random() * available.length)] ?? allItems[Math.floor(Math.random() * allItems.length)];
+    return choice;
+  }
+
+  function showDailyReward(item) {
+    dom.dailyReward.innerHTML = "";
+    const card = createCardElement(item);
+    dom.dailyReward.append(card);
+  }
+
+  function updateDailyLoginUI() {
+    dom.dailyStreak.textContent = loginState.streak;
+    dom.heroStreak.textContent = loginState.streak;
+
+    if (canClaimToday()) {
+      dom.claimLogin.disabled = false;
+      dom.loginStatus.textContent = "Bereit für deinen Bonus!";
+      dom.dailyReward.innerHTML = "<p>Hole dir den Bonus, um deine Überraschung zu enthüllen.</p>";
+    } else {
+      dom.claimLogin.disabled = true;
+      dom.loginStatus.textContent = "Schon abgeholt – komm morgen wieder.";
+    }
+
+    const nextMilestone = findNextMilestone(loginState.streak);
+    dom.nextMilestone.textContent = nextMilestone;
+  }
+
+  function findNextMilestone(streak) {
+    const upcoming = [7, 14, 21].find((value) => value > streak);
+    if (!upcoming) {
+      return "Streak-Legende! Halte deine Serie für weitere Überraschungen.";
+    }
+    const label = upcoming === 14 ? "Legendäre Auswahl" : upcoming === 7 ? "Epische Karte" : "Mysteriöser Bonus";
+    return `Tag ${upcoming}: ${label}`;
+  }
+
+  function setupEventCountdown() {
+    if (limitedEventItem) {
+      dom.eventItem.textContent = limitedEventItem.name;
+    }
+
+    const target = eventState.endsAt;
+    updateCountdown();
+    setInterval(updateCountdown, 1000);
+
+    function updateCountdown() {
+      const now = Date.now();
+      const diff = Math.max(0, target - now);
+      const totalSeconds = Math.floor(diff / 1000);
+      const hours = Math.floor(totalSeconds / 3600);
+      const minutes = Math.floor((totalSeconds % 3600) / 60);
+      const seconds = totalSeconds % 60;
+      dom.eventCountdown.textContent = `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+    }
+  }
+
+  function updateHeroStats() {
+    dom.heroStreak.textContent = loginState.streak;
+
+    const itemCounts = collectionState.items ?? {};
+    const ownedItems = Object.keys(itemCounts).filter((id) => itemCounts[id] > 0);
+    const highest = ownedItems
+      .map((id) => itemsById.get(id))
+      .filter(Boolean)
+      .sort((a, b) => rarityScore[b.rarity] - rarityScore[a.rarity])[0];
+    const fallbackName = limitedEventItem?.name ?? "–";
+    dom.legendaryHighlight.textContent = highest ? highest.name : fallbackName;
+  }
+
+  function setupMultiplayerArena() {
+    const playerNodes = document.querySelectorAll("[data-duel-player]");
+    dom.duelPlayers = Array.from(playerNodes).map((node) => ({
+      root: node,
+      name: node.querySelector(".duel-player-name"),
+      status: node.querySelector(".duel-player-status"),
+      health: node.querySelector(".duel-health-value"),
+      deck: node.querySelector(".duel-deck-count"),
+      handCount: node.querySelector(".duel-hand-count"),
+      boardCount: node.querySelector(".duel-board-count"),
+      crystals: node.querySelector(".duel-crystals"),
+      hero: node.querySelector("[data-duel-hero]"),
+      board: node.querySelector("[data-duel-board]"),
+      hand: node.querySelector("[data-duel-hand]"),
+    }));
+
+    if (dom.duelStart) {
+      dom.duelStart.addEventListener("click", startDuel);
+    }
+    if (dom.duelEndTurn) {
+      dom.duelEndTurn.addEventListener("click", endTurn);
+    }
+    if (dom.duelTargetCancel) {
+      dom.duelTargetCancel.addEventListener("click", cancelTargetSelection);
+    }
+    if (dom.duelPlayers && dom.duelPlayers.length > 0) {
+      dom.duelPlayers.forEach((entry, index) => {
+        if (entry.hand) {
+          entry.hand.addEventListener("click", (event) => handleHandClick(event, index));
+        }
+        if (entry.board) {
+          entry.board.addEventListener("click", (event) => handleBoardClick(event, index));
+        }
+        if (entry.hero) {
+          entry.hero.addEventListener("click", (event) => handleHeroClick(event, index));
+        }
+      });
+    }
+
+    renderDuel();
+  }
+
+  function createIdlePlayerState(name) {
+    return {
+      name,
+      health: duelConfig.startingHealth,
+      deck: [],
+      hand: [],
+      board: [],
+      crystals: 0,
+      maxCrystals: 0,
+      startingDeck: [],
+      deckName: sanitizeDeckName(collectionState.deck?.name ?? "Arena-Starter"),
+    };
+  }
+
+  function createPlayerState(name) {
+    const deckCards = buildDeck();
+    return {
+      name,
+      health: duelConfig.startingHealth,
+      deck: deckCards.slice(),
+      hand: [],
+      board: [],
+      crystals: 0,
+      maxCrystals: 0,
+      startingDeck: deckCards.slice(),
+      deckName: sanitizeDeckName(collectionState.deck?.name ?? "Arena-Starter"),
+    };
+  }
+
+  function buildDeck() {
+    const pool = [];
+    const owned = collectionState.items ?? {};
+    const deck = collectionState.deck ?? { cards: {} };
+    Object.entries(deck.cards ?? {}).forEach(([cardId, value]) => {
+      const item = itemsById.get(cardId);
+      if (!item) {
+        return;
+      }
+      const desired = Math.max(0, Math.floor(Number(value) || 0));
+      if (desired <= 0) {
+        return;
+      }
+      const ownedCount = Math.max(0, Math.floor(Number(owned[cardId]) || 0));
+      if (ownedCount <= 0) {
+        return;
+      }
+      const allowed = Math.min(desired, ownedCount);
+      for (let i = 0; i < allowed; i += 1) {
+        pool.push(cardId);
+      }
+    });
+    if (pool.length === 0) {
+      return [];
+    }
+    const shuffled = shuffle(pool);
+    if (shuffled.length > duelConfig.deckSize) {
+      return shuffled.slice(0, duelConfig.deckSize);
+    }
+    return shuffled;
+  }
+
+  function shuffle(source) {
+    const array = source.slice();
+    for (let i = array.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [array[i], array[j]] = [array[j], array[i]];
+    }
+    return array;
+  }
+
+  function startDuel() {
+    resetInteractionState();
+    duelState.status = "active";
+    duelState.players = duelDefaultNames.map((name) => createPlayerState(name));
+    duelState.activePlayer = 0;
+    duelState.turnCounter = 0;
+    duelState.winner = undefined;
+    duelState.nextUnitId = 1;
+    duelState.log = [];
+    if (dom.duelLog) {
+      dom.duelLog.innerHTML = "";
+    }
+
+    duelState.players.forEach((player, index) => {
+      const initialDraws = duelConfig.startingHandSize + (index === 1 ? 1 : 0);
+      for (let i = 0; i < initialDraws; i += 1) {
+        drawCard(player);
+      }
+    });
+
+    logDuel("Arena geöffnet – Decks wurden gemischt.");
+    duelState.players.forEach((player) => {
+      const startingCount = player.startingDeck?.length ?? 0;
+      const uniqueCount = new Set(player.startingDeck ?? []).size;
+      const deckName = player.deckName && player.deckName.length > 0 ? `„${player.deckName}“` : undefined;
+      if (startingCount === 0) {
+        logDuel(
+          `${player.name} hat kein gespeichertes Deck – baue eines in der Deck-Werkstatt, um anzutreten.`
+        );
+      } else if (startingCount < duelConfig.deckSize) {
+        logDuel(
+          `${player.name} spielt ${deckName ? `das Deck ${deckName}` : "sein aktives Deck"} mit ${startingCount}/${duelConfig.deckSize} Karten (${uniqueCount} einzigartig).`
+        );
+      } else {
+        logDuel(
+          `${player.name} bringt ${deckName ? `das Deck ${deckName}` : "sein aktives Deck"} mit ${startingCount} Karten (${uniqueCount} einzigartig) an den Start.`
+        );
+      }
+    });
+    beginTurn();
+  }
+
+  function resetInteractionState() {
+    duelInteraction.mode = "idle";
+    duelInteraction.sourcePlayer = undefined;
+    duelInteraction.sourceUnitId = undefined;
+    duelInteraction.pendingSpell = undefined;
+    duelInteraction.targets = [];
+    duelInteraction.targetKeys = new Set();
+  }
+
+  function setInteractionTargets(targets) {
+    duelInteraction.targets = targets;
+    duelInteraction.targetKeys = new Set(targets.map((target) => createTargetKey(target)));
+  }
+
+  function createTargetKey(target) {
+    if (!target) {
+      return "";
+    }
+    if (target.type === "unit") {
+      return `unit:${target.playerIndex}:${target.unitId ?? target.unit?.instanceId ?? ""}`;
+    }
+    if (target.type === "hero") {
+      return `hero:${target.playerIndex}`;
+    }
+    return "";
+  }
+
+  function isTargetKeyActive(target) {
+    const key = createTargetKey(target);
+    if (!key) {
+      return false;
+    }
+    return duelInteraction.targetKeys.has(key);
+  }
+
+  function findInteractionTarget(type, playerIndex, unitId) {
+    const key = createTargetKey({ type, playerIndex, unitId });
+    return duelInteraction.targets.find((entry) => createTargetKey(entry) === key);
+  }
+
+  function beginTurn() {
+    if (duelState.status !== "active") {
+      renderDuel();
+      return;
+    }
+
+    resetInteractionState();
+    duelState.turnCounter += 1;
+    const player = duelState.players[duelState.activePlayer];
+    if (!player) {
+      renderDuel();
+      return;
+    }
+
+    player.maxCrystals = Math.min(duelConfig.maxCrystals, player.maxCrystals + 1);
+    player.crystals = player.maxCrystals;
+    readyBoardUnits(player);
+
+    const drawn = drawCard(player);
+    if (drawn) {
+      logDuel(
+        `${player.name} beginnt den Zug, zieht ${drawn.name} und verfügt über ${player.crystals}/${player.maxCrystals} Kristalle.`
+      );
+    } else {
+      logDuel(`${player.name} beginnt den Zug, aber das Deck ist leer.`);
+      checkDeckDefeat(duelState.activePlayer);
+    }
+
+    renderDuel();
+  }
+
+  function readyBoardUnits(player) {
+    if (!player || !Array.isArray(player.board)) {
+      return;
+    }
+    player.board.forEach((unit) => {
+      if (!unit || unit.health <= 0) {
+        return;
+      }
+      unit.extraAttacks = 0;
+      if (unit.stunnedTurns && unit.stunnedTurns > 0) {
+        unit.stunnedTurns = Math.max(0, unit.stunnedTurns - 1);
+        unit.exhausted = true;
+        unit.hasAttacked = true;
+      } else {
+        unit.exhausted = false;
+        unit.hasAttacked = false;
+      }
+    });
+  }
+
+  function endTurn() {
+    if (duelState.status !== "active") {
+      return;
+    }
+    const currentIndex = duelState.activePlayer;
+    resetInteractionState();
+    const player = duelState.players[currentIndex];
+    if (player) {
+      logDuel(`${player.name} beendet den Zug.`);
+    }
+    duelState.activePlayer = (currentIndex + 1) % duelState.players.length;
+    beginTurn();
+  }
+
+  function handleHandClick(event, playerIndex) {
+    const button = event.target.closest("button[data-card-index]");
+    if (!button || button.disabled) {
+      return;
+    }
+    const cardIndex = Number.parseInt(button.dataset.cardIndex ?? "", 10);
+    if (Number.isNaN(cardIndex)) {
+      return;
+    }
+    if (duelInteraction.mode === "spell") {
+      const pending = duelInteraction.pendingSpell;
+      if (pending && pending.playerIndex === playerIndex && pending.cardIndex === cardIndex) {
+        cancelSpellTargeting();
+      }
+      return;
+    }
+    if (duelInteraction.mode === "attack") {
+      if (duelInteraction.sourcePlayer === playerIndex) {
+        resetInteractionState();
+      } else {
+        return;
+      }
+    }
+    playCardFromHand(playerIndex, cardIndex);
+  }
+
+  function getEffectiveCardCost(card, playerIndex) {
+    if (!card) {
+      return Number.POSITIVE_INFINITY;
+    }
+    let cost = Number(card.cost);
+    if (!Number.isFinite(cost)) {
+      cost = 0;
+    }
+    const player = duelState.players[playerIndex];
+    if (player && card.cardType === "spell") {
+      const reduction = (player.board ?? []).reduce((total, unit) => {
+        if (unit && unit.health > 0 && unit.cardId === "elder-dryad") {
+          return total + 1;
+        }
+        return total;
+      }, 0);
+      if (reduction > 0) {
+        cost = Math.max(0, cost - reduction);
+      }
+    }
+    return cost;
+  }
+
+  function playCardFromHand(playerIndex, cardIndex) {
+    if (duelState.status !== "active" || duelState.activePlayer !== playerIndex) {
+      return;
+    }
+
+    const player = duelState.players[playerIndex];
+    if (!player) {
+      return;
+    }
+
+    const cardId = player.hand[cardIndex];
+    const card = cardId ? itemsById.get(cardId) : undefined;
+    if (!card) {
+      return;
+    }
+
+    const cardCost = getEffectiveCardCost(card, playerIndex);
+    if (cardCost > player.crystals) {
+      return;
+    }
+
+    if (card.cardType === "spell") {
+      const opponentIndex = (playerIndex + 1) % duelState.players.length;
+      const targeting = getSpellTargetOptions(card, playerIndex, opponentIndex);
+      if (targeting.requiresTarget && targeting.targets.length > 0) {
+        beginSpellTargeting(playerIndex, cardIndex, card, targeting);
+        return;
+      }
+    }
+
+    if (card.cardType !== "spell" && player.board.length >= duelConfig.boardLimit) {
+      logDuel(`${player.name} kann ${card.name} nicht spielen – das Feld ist voll.`);
+      return;
+    }
+
+    player.crystals -= cardCost;
+    player.hand.splice(cardIndex, 1);
+
+    let summary = `${player.name} spielt ${card.name} für ${cardCost} Kristalle.`;
+    if (card.cardType === "spell") {
+      const opponentIndex = (playerIndex + 1) % duelState.players.length;
+      const effectSummary = resolveSpell(card, playerIndex, opponentIndex);
+      if (effectSummary) {
+        summary += ` ${effectSummary}`;
+      }
+    } else {
+      const summonSummary = summonUnit(card, playerIndex);
+      if (summonSummary) {
+        summary += ` ${summonSummary}`;
+      }
+    }
+
+    logDuel(summary);
+    checkDeckDefeat(playerIndex);
+    checkDeckDefeat((playerIndex + 1) % duelState.players.length);
+    renderDuel();
+  }
+
+  function beginSpellTargeting(playerIndex, cardIndex, card, targeting) {
+    resetInteractionState();
+    duelInteraction.mode = "spell";
+    duelInteraction.pendingSpell = {
+      playerIndex,
+      cardIndex,
+      cardId: card.id,
+      card,
+    };
+    setInteractionTargets(targeting.targets);
+    const player = duelState.players[playerIndex];
+    if (player) {
+      logDuel(`${player.name} kanalisiert ${card.name} – wähle ein Ziel.`);
+    }
+    renderDuel();
+  }
+
+  function cancelSpellTargeting() {
+    if (duelInteraction.mode !== "spell") {
+      return;
+    }
+    const pending = duelInteraction.pendingSpell;
+    const player = pending ? duelState.players[pending.playerIndex] : undefined;
+    if (player && pending?.card) {
+      logDuel(`${player.name} bricht ${pending.card.name} ab.`);
+    }
+    resetInteractionState();
+    renderDuel();
+  }
+
+  function cancelTargetSelection() {
+    if (duelInteraction.mode === "spell") {
+      cancelSpellTargeting();
+      return;
+    }
+    if (duelInteraction.mode === "attack") {
+      const attackerIndex = duelInteraction.sourcePlayer;
+      const attackerUnitId = duelInteraction.sourceUnitId;
+      const { player, unit } = findUnit(attackerIndex, attackerUnitId);
+      if (player && unit) {
+        logDuel(`${player.name} hält ${unit.name} vom Angriff zurück.`);
+      }
+      resetInteractionState();
+      renderDuel();
+    }
+  }
+
+  function resolvePendingSpell(target) {
+    const pending = duelInteraction.pendingSpell;
+    if (!pending) {
+      return;
+    }
+    const { playerIndex, cardIndex, cardId, card } = pending;
+    const player = duelState.players[playerIndex];
+    if (!player || !card) {
+      resetInteractionState();
+      renderDuel();
+      return;
+    }
+    let handIndex = cardIndex;
+    if (player.hand[handIndex] !== cardId) {
+      handIndex = player.hand.indexOf(cardId);
+    }
+    if (handIndex < 0) {
+      resetInteractionState();
+      renderDuel();
+      return;
+    }
+    if (card.cost > player.crystals) {
+      logDuel(`${player.name} kann ${card.name} nicht wirken – zu wenig Kristalle.`);
+      resetInteractionState();
+      renderDuel();
+      return;
+    }
+    player.crystals -= card.cost;
+    player.hand.splice(handIndex, 1);
+    resetInteractionState();
+    const opponentIndex = (playerIndex + 1) % duelState.players.length;
+    let summary = `${player.name} spielt ${card.name} für ${card.cost} Kristalle.`;
+    const effectSummary = resolveSpell(card, playerIndex, opponentIndex, target);
+    if (effectSummary) {
+      summary += ` ${effectSummary}`;
+    }
+    logDuel(summary);
+    checkDeckDefeat(playerIndex);
+    checkDeckDefeat(opponentIndex);
+    renderDuel();
+  }
+
+  function getSpellTargetOptions(card, playerIndex, opponentIndex) {
+    const effect = card.effect ?? {};
+    const targets = [];
+    let requiresTarget = false;
+    switch (effect.type) {
+      case "directDamage": {
+        const opponent = duelState.players[opponentIndex];
+        if (opponent) {
+          requiresTarget = true;
+          targets.push({ type: "hero", playerIndex: opponentIndex });
+        }
+        break;
+      }
+      case "enemyUnitDamage": {
+        const opponent = duelState.players[opponentIndex];
+        if (opponent) {
+          const units = (opponent.board ?? []).filter((unit) => unit && unit.health > 0);
+          units.forEach((unit) => {
+            targets.push({ type: "unit", playerIndex: opponentIndex, unitId: unit.instanceId });
+          });
+          if (targets.length === 0) {
+            targets.push({ type: "hero", playerIndex: opponentIndex });
+          }
+          requiresTarget = targets.length > 0;
+        }
+        break;
+      }
+      case "allyHeal": {
+        const player = duelState.players[playerIndex];
+        if (player) {
+          const allies = (player.board ?? []).filter(
+            (unit) => unit && unit.health > 0 && unit.health < unit.maxHealth
+          );
+          allies.forEach((unit) => {
+            targets.push({ type: "unit", playerIndex, unitId: unit.instanceId });
+          });
+          if (player.health < duelConfig.startingHealth) {
+            targets.push({ type: "hero", playerIndex });
+          }
+          requiresTarget = targets.length > 0;
+        }
+        break;
+      }
+      case "grantBarrier":
+      case "grantExtraAttack": {
+        const player = duelState.players[playerIndex];
+        if (player) {
+          const allies = (player.board ?? []).filter((unit) => unit && unit.health > 0);
+          allies.forEach((unit) => {
+            targets.push({ type: "unit", playerIndex, unitId: unit.instanceId });
+          });
+          requiresTarget = targets.length > 0;
+        }
+        break;
+      }
+      case "stun": {
+        const opponent = duelState.players[opponentIndex];
+        if (opponent) {
+          const enemies = (opponent.board ?? []).filter((unit) => unit && unit.health > 0);
+          enemies.forEach((unit) => {
+            targets.push({ type: "unit", playerIndex: opponentIndex, unitId: unit.instanceId });
+          });
+          requiresTarget = targets.length > 0;
+        }
+        break;
+      }
+      default:
+        requiresTarget = false;
+        break;
+    }
+    return { requiresTarget, targets };
+  }
+
+  function handleBoardClick(event, playerIndex) {
+    const card = event.target.closest("[data-unit-id]");
+    if (!card) {
+      return;
+    }
+    const unitId = card.dataset.unitId;
+    if (!unitId) {
+      return;
+    }
+    if (duelInteraction.mode === "spell") {
+      if (isTargetKeyActive({ type: "unit", playerIndex, unitId })) {
+        const target = findInteractionTarget("unit", playerIndex, unitId);
+        resolvePendingSpell(target);
+      }
+      return;
+    }
+    if (duelInteraction.mode === "attack") {
+      if (duelInteraction.sourcePlayer === playerIndex) {
+        if (duelInteraction.sourceUnitId === unitId) {
+          resetInteractionState();
+          renderDuel();
+        } else {
+          selectAttackingUnit(playerIndex, unitId);
+        }
+      } else if (isTargetKeyActive({ type: "unit", playerIndex, unitId })) {
+        const target = findInteractionTarget("unit", playerIndex, unitId);
+        resolveAttackTarget(target);
+      }
+      return;
+    }
+    if (duelState.status !== "active" || duelState.activePlayer !== playerIndex) {
+      return;
+    }
+    selectAttackingUnit(playerIndex, unitId);
+  }
+
+  function handleHeroClick(event, playerIndex) {
+    if (duelInteraction.mode === "spell") {
+      if (isTargetKeyActive({ type: "hero", playerIndex })) {
+        const target = findInteractionTarget("hero", playerIndex);
+        resolvePendingSpell(target);
+      }
+      return;
+    }
+    if (duelInteraction.mode === "attack") {
+      if (duelInteraction.sourcePlayer === playerIndex) {
+        resetInteractionState();
+        renderDuel();
+      } else if (isTargetKeyActive({ type: "hero", playerIndex })) {
+        const target = findInteractionTarget("hero", playerIndex);
+        resolveAttackTarget(target);
+      }
+    }
+  }
+
+  function selectAttackingUnit(playerIndex, unitId) {
+    if (duelState.status !== "active" || duelState.activePlayer !== playerIndex) {
+      return;
+    }
+    const { player, unit } = findUnit(playerIndex, unitId);
+    if (!player || !unit || unit.health <= 0) {
+      return;
+    }
+    const attackValue = Number(unit.attack);
+    const extraCharges = Number(unit.extraAttacks ?? 0);
+    if (attackValue <= 0) {
+      return;
+    }
+    const isExhausted = unit.exhausted && extraCharges <= 0;
+    const hasNoCharges = unit.hasAttacked && extraCharges <= 0;
+    if (isExhausted || hasNoCharges) {
+      return;
+    }
+    const targets = getAttackTargets(playerIndex, unit);
+    if (targets.length === 0) {
+      logDuel(`${player.name}s ${unit.name} hat derzeit keine gültigen Ziele.`);
+      return;
+    }
+    resetInteractionState();
+    duelInteraction.mode = "attack";
+    duelInteraction.sourcePlayer = playerIndex;
+    duelInteraction.sourceUnitId = unitId;
+    duelInteraction.pendingSpell = undefined;
+    setInteractionTargets(targets);
+    renderDuel();
+  }
+
+  function getAttackTargets(playerIndex, unit) {
+    const opponentIndex = (playerIndex + 1) % duelState.players.length;
+    const opponent = duelState.players[opponentIndex];
+    if (!opponent) {
+      return [];
+    }
+    const targets = [];
+    const enemyUnits = (opponent.board ?? []).filter((entry) => entry && entry.health > 0);
+    const bulwarks = enemyUnits.filter((entry) => entry.bulwark);
+    const candidates = bulwarks.length > 0 ? bulwarks : enemyUnits;
+    candidates.forEach((enemy) => {
+      targets.push({ type: "unit", playerIndex: opponentIndex, unitId: enemy.instanceId });
+    });
+    if (bulwarks.length === 0) {
+      targets.push({ type: "hero", playerIndex: opponentIndex });
+    }
+    return targets;
+  }
+
+  function resolveAttackTarget(target) {
+    if (!target) {
+      return;
+    }
+    if (duelState.status !== "active") {
+      resetInteractionState();
+      renderDuel();
+      return;
+    }
+    const attackerIndex = duelInteraction.sourcePlayer;
+    const unitId = duelInteraction.sourceUnitId;
+    const { player: attacker, unit } = findUnit(attackerIndex, unitId);
+    if (!attacker || !unit || unit.health <= 0) {
+      resetInteractionState();
+      renderDuel();
+      return;
+    }
+    resetInteractionState();
+    const defenderIndex = target.playerIndex;
+    const defender = duelState.players[defenderIndex];
+    if (!defender) {
+      renderDuel();
+      return;
+    }
+    if (target.type === "hero") {
+      const defenderHasBulwark = (defender.board ?? []).some(
+        (entry) => entry && entry.health > 0 && entry.bulwark
+      );
+      if (defenderHasBulwark) {
+        logDuel(
+          `${defender.name} wird von einem Bollwerk beschützt – ${attacker.name}s ${unit.name} findet kein Ziel.`
+        );
+        renderDuel();
+        return;
+      }
+      const damage = Math.max(0, unit.attack);
+      logDuel(`${attacker.name}s ${unit.name} greift ${defender.name} an und verursacht ${damage} Schaden.`);
+      const result = applyHeroDamage(defenderIndex, damage);
+      unit.exhausted = true;
+      unit.hasAttacked = true;
+      if (result.actual > 0) {
+        logDuel(`${defender.name} verbleiben ${defender.health} Lebenspunkte.`);
+      }
+      if (result.defeated) {
+        finishDuel(attackerIndex, `${attacker.name} gewinnt die Arena!`);
+        return;
+      }
+      renderDuel();
+      return;
+    }
+    if (target.type === "unit") {
+      const { unit: enemyUnit } = findUnit(defenderIndex, target.unitId);
+      if (!enemyUnit || enemyUnit.health <= 0) {
+        renderDuel();
+        return;
+      }
+      logDuel(`${attacker.name}s ${unit.name} attackiert ${defender.name}s ${enemyUnit.name}.`);
+      const strike = applyDamageToUnit(defenderIndex, enemyUnit, unit.attack);
+      if (strike.actual > 0) {
+        if (strike.destroyed) {
+          logDuel(`${defender.name}s ${enemyUnit.name} wird zerstört.`);
+          removeUnit(defenderIndex, enemyUnit);
+        } else {
+          logDuel(`${defender.name}s ${enemyUnit.name} verbleiben ${enemyUnit.health}/${enemyUnit.maxHealth} Leben.`);
+        }
+      } else {
+        logDuel(`${enemyUnit.name} wird nicht verletzt.`);
+      }
+      if (enemyUnit.health > 0) {
+        const retaliation = applyDamageToUnit(attackerIndex, unit, enemyUnit.attack);
+        if (retaliation.actual > 0) {
+          if (retaliation.destroyed) {
+            logDuel(`${attacker.name}s ${unit.name} wird im Gegenschlag zerstört.`);
+            removeUnit(attackerIndex, unit);
+          } else {
+            logDuel(`${attacker.name}s ${unit.name} verbleiben ${unit.health}/${unit.maxHealth} Leben.`);
+          }
+        }
+      }
+      if (unit.health > 0) {
+        if (unit.extraAttacks && unit.extraAttacks > 0) {
+          unit.extraAttacks = Math.max(0, unit.extraAttacks - 1);
+          if (unit.extraAttacks > 0) {
+            unit.exhausted = false;
+            unit.hasAttacked = false;
+          } else {
+            unit.exhausted = true;
+            unit.hasAttacked = true;
+          }
+        } else {
+          unit.exhausted = true;
+          unit.hasAttacked = true;
+        }
+      }
+      checkDeckDefeat(defenderIndex);
+      checkDeckDefeat(attackerIndex);
+      renderDuel();
+    }
+  }
+
+  function findUnit(playerIndex, unitId) {
+    const player = duelState.players[playerIndex];
+    if (!player || !Array.isArray(player.board)) {
+      return { player: undefined, unit: undefined };
+    }
+    const unit = player.board.find((entry) => entry && entry.instanceId === unitId);
+    return { player, unit };
+  }
+
+  function createUnitInstance(card) {
+    if (!card) {
+      return null;
+    }
+    const attack = Math.max(0, card.damage ?? 0);
+    const maxHealth = Math.max(1, card.health ?? 1);
+    const unit = {
+      instanceId: `u${duelState.nextUnitId}`,
+      cardId: card.id,
+      name: card.name,
+      attack,
+      health: maxHealth,
+      maxHealth,
+      bulwark: card.abilities?.includes("bulwark") ?? false,
+      exhausted: true,
+      hasAttacked: false,
+      extraAttacks: 0,
+      stunnedTurns: 0,
+    };
+    duelState.nextUnitId += 1;
+    return unit;
+  }
+
+  function summonUnit(card, playerIndex) {
+    const player = duelState.players[playerIndex];
+    if (!player) {
+      return undefined;
+    }
+    const unit = createUnitInstance(card);
+    if (!unit) {
+      return undefined;
+    }
+    if (!Array.isArray(player.board)) {
+      player.board = [];
+    }
+    player.board.push(unit);
+    if (unit.bulwark) {
+      return `Beschwört ein Bollwerk (${unit.attack}/${unit.maxHealth}).`;
+    }
+    return `Beschwört eine Einheit (${unit.attack}/${unit.maxHealth}).`;
+  }
+
+  function resolveSpell(card, playerIndex, opponentIndex, target) {
+    const player = duelState.players[playerIndex];
+    const opponent = duelState.players[opponentIndex];
+    const effect = card.effect ?? {};
+    const amount = effect.amount ?? card.damage ?? 0;
+
+    switch (effect.type) {
+      case "directDamage": {
+        const heroIndex = target?.type === "hero" ? target.playerIndex : opponentIndex;
+        const defender = duelState.players[heroIndex];
+        if (!defender) {
+          return undefined;
+        }
+        const result = applyHeroDamage(heroIndex, amount);
+        if (result.actual > 0) {
+          logDuel(`${defender.name} erleidet ${result.actual} Schaden (${defender.health} Lebenspunkte verbleiben).`);
+        }
+        if (result.defeated) {
+          finishDuel(playerIndex, `${player?.name ?? "Der Angreifer"} gewinnt die Arena!`);
+        }
+        if (result.actual > 0) {
+          return `${defender.name} erleidet ${result.actual} Schaden.`;
+        }
+        return `${defender.name} bleibt unverletzt.`;
+      }
+      case "enemyUnitDamage": {
+        if (target?.type === "unit") {
+          const defenderInfo = findUnit(target.playerIndex, target.unitId);
+          const defenderUnit = defenderInfo.unit;
+          const defenderPlayer = defenderInfo.player;
+          if (!defenderUnit || !defenderPlayer) {
+            logDuel(`${card.name} findet sein Ziel nicht mehr.`);
+            return `Das Ziel ist nicht mehr im Spiel.`;
+          }
+          const strike = applyDamageToUnit(target.playerIndex, defenderUnit, amount);
+          let description;
+          if (strike.actual > 0) {
+            if (strike.destroyed) {
+              logDuel(`${card.name} zerstört ${defenderPlayer.name}s ${defenderUnit.name}.`);
+              removeUnit(target.playerIndex, defenderUnit);
+            } else {
+              logDuel(`${card.name} fügt ${defenderPlayer.name}s ${defenderUnit.name} ${strike.actual} Schaden zu (${defenderUnit.health}/${defenderUnit.maxHealth}).`);
+            }
+            description = `${defenderPlayer.name}s ${defenderUnit.name} erleidet ${strike.actual} Schaden.`;
+          } else {
+            logDuel(`${card.name} zeigt keine Wirkung gegen ${defenderUnit.name}.`);
+            description = `${defenderUnit.name} widersteht dem Zauber.`;
+          }
+          checkDeckDefeat(target.playerIndex);
+          return description;
+        }
+        if (target?.type === "hero") {
+          const defenderPlayer = duelState.players[target.playerIndex];
+          if (!defenderPlayer) {
+            return undefined;
+          }
+          const fallback = applyHeroDamage(target.playerIndex, amount);
+          let description;
+          if (fallback.actual > 0) {
+            logDuel(`${card.name} trifft ${defenderPlayer.name} für ${fallback.actual} Schaden (${defenderPlayer.health} Lebenspunkte).`);
+            description = `${defenderPlayer.name} erleidet ${fallback.actual} Schaden.`;
+          } else {
+            description = `${defenderPlayer.name} bleibt unverletzt.`;
+          }
+          if (fallback.defeated) {
+            finishDuel(playerIndex, `${player?.name ?? "Der Angreifer"} gewinnt die Arena!`);
+          }
+          return description;
+        }
+        if (!opponent) {
+          return undefined;
+        }
+        if (!opponent.board || opponent.board.length === 0) {
+          const fallback = applyHeroDamage(opponentIndex, amount);
+          if (fallback.actual > 0) {
+            logDuel(`${card.name} trifft ${opponent.name} für ${fallback.actual} Schaden (${opponent.health} Lebenspunkte).`);
+          }
+          if (fallback.defeated) {
+            finishDuel(playerIndex, `${player?.name ?? "Der Angreifer"} gewinnt die Arena!`);
+          }
+          return `Keine Karte im Feld – ${opponent.name} erleidet ${fallback.actual} Schaden.`;
+        }
+        const autoTarget = chooseEnemyUnitForSpell(opponent);
+        if (!autoTarget) {
+          return undefined;
+        }
+        const result = applyDamageToUnit(opponentIndex, autoTarget.unit, amount);
+        if (result.actual > 0) {
+          if (result.destroyed) {
+            logDuel(`${card.name} zerstört ${opponent.name}s ${autoTarget.unit.name}.`);
+            removeUnit(opponentIndex, autoTarget.unit);
+          } else {
+            logDuel(`${card.name} fügt ${opponent.name}s ${autoTarget.unit.name} ${result.actual} Schaden zu (${autoTarget.unit.health}/${autoTarget.unit.maxHealth}).`);
+          }
+        } else {
+          logDuel(`${card.name} zeigt keine Wirkung gegen ${opponent.name}s ${autoTarget.unit.name}.`);
+        }
+        checkDeckDefeat(opponentIndex);
+        return `Trifft eine gegnerische Karte für ${amount} Schaden.`;
+      }
+      case "damageAllEnemies": {
+        if (!opponent) {
+          return undefined;
+        }
+        if (!opponent.board || opponent.board.length === 0) {
+          const fallback = applyHeroDamage(opponentIndex, amount);
+          if (fallback.actual > 0) {
+            logDuel(`${card.name} trifft ${opponent.name} für ${fallback.actual} Schaden (${opponent.health} Lebenspunkte verbleiben).`);
+          }
+          if (fallback.defeated) {
+            finishDuel(playerIndex, `${player?.name ?? "Der Angreifer"} gewinnt die Arena!`);
+          }
+          return `Es gibt keine gegnerischen Karten – ${opponent.name} erleidet ${fallback.actual} Schaden.`;
+        }
+        opponent.board.slice().forEach((unit) => {
+          const result = applyDamageToUnit(opponentIndex, unit, amount);
+          if (result.actual > 0) {
+            if (result.destroyed) {
+              logDuel(`${card.name} lässt ${opponent.name}s ${unit.name} vergehen.`);
+              removeUnit(opponentIndex, unit);
+            } else {
+              logDuel(`${card.name} trifft ${opponent.name}s ${unit.name} für ${result.actual} Schaden (${unit.health}/${unit.maxHealth}).`);
+            }
+          }
+        });
+        checkDeckDefeat(opponentIndex);
+        return `Trifft alle gegnerischen Karten für ${amount} Schaden.`;
+      }
+      case "healHero": {
+        const heroIndex = target?.type === "hero" ? target.playerIndex : playerIndex;
+        const heroPlayer = duelState.players[heroIndex];
+        if (!heroPlayer) {
+          return undefined;
+        }
+        const healed = healHero(heroIndex, amount);
+        if (healed > 0) {
+          logDuel(`${card.name} heilt ${heroPlayer.name} um ${healed} Lebenspunkte (${heroPlayer.health} LP).`);
+          return `Heilt ${heroPlayer.name} um ${healed} Lebenspunkte.`;
+        }
+        logDuel(`${card.name} verpufft – ${heroPlayer.name} ist bereits bei voller Gesundheit.`);
+        return `${heroPlayer.name} ist bereits bei voller Gesundheit.`;
+      }
+      case "allyHeal": {
+        if (target?.type === "unit") {
+          const allyInfo = findUnit(target.playerIndex, target.unitId);
+          const allyUnit = allyInfo.unit;
+          const owner = allyInfo.player;
+          if (!allyUnit || !owner) {
+            logDuel(`${card.name} findet kein gültiges Verbündeten-Ziel.`);
+            return `Keine Wirkung – das Ziel ist nicht mehr im Spiel.`;
+          }
+          const healedUnit = healUnit(allyUnit, amount);
+          if (healedUnit > 0) {
+            logDuel(`${card.name} heilt ${owner.name}s ${allyUnit.name} um ${healedUnit} Leben (${allyUnit.health}/${allyUnit.maxHealth}).`);
+            return `Heilt ${allyUnit.name} um ${healedUnit} Leben.`;
+          }
+          logDuel(`${card.name} zeigt keine Wirkung auf ${allyUnit.name}.`);
+          return `${allyUnit.name} ist bereits bei voller Gesundheit.`;
+        }
+        if (target?.type === "hero") {
+          const heroPlayer = duelState.players[target.playerIndex];
+          if (!heroPlayer) {
+            return undefined;
+          }
+          const healedHero = healHero(target.playerIndex, amount);
+          if (healedHero > 0) {
+            logDuel(`${card.name} heilt ${heroPlayer.name} um ${healedHero} Lebenspunkte (${heroPlayer.health} LP).`);
+            return `Heilt ${heroPlayer.name} um ${healedHero} Lebenspunkte.`;
+          }
+          logDuel(`${card.name} verpufft – ${heroPlayer.name} ist bereits bei voller Gesundheit.`);
+          return `${heroPlayer.name} ist bereits bei voller Gesundheit.`;
+        }
+        const outcome = healAlly(playerIndex, amount, card.name);
+        return outcome?.description ?? undefined;
+      }
+      case "grantBarrier": {
+        if (target?.type !== "unit") {
+          logDuel(`${card.name} findet kein gültiges Ziel für zusätzliche Barriere.`);
+          return `Keine Wirkung – es ist kein Diener als Ziel verfügbar.`;
+        }
+        const allyInfo = findUnit(target.playerIndex, target.unitId);
+        const allyUnit = allyInfo.unit;
+        const owner = allyInfo.player;
+        if (!allyUnit || !owner) {
+          logDuel(`${card.name} findet kein gültiges Verbündeten-Ziel.`);
+          return `Keine Wirkung – das Ziel ist nicht mehr im Spiel.`;
+        }
+        const granted = fortifyUnit(allyUnit, amount);
+        if (granted > 0) {
+          logDuel(
+            `${card.name} verstärkt ${owner.name}s ${allyUnit.name} um ${granted} Barriere (${allyUnit.health}/${allyUnit.maxHealth}).`
+          );
+          return `${allyUnit.name} erhält +${granted} Barriere.`;
+        }
+        logDuel(`${card.name} zeigt keine Wirkung auf ${allyUnit.name}.`);
+        return `${allyUnit.name} bleibt unverändert.`;
+      }
+      case "summonUnits": {
+        if (!player) {
+          return undefined;
+        }
+        const summonId = effect.cardId;
+        const template = summonId ? itemsById.get(summonId) : undefined;
+        if (!template) {
+          logDuel(`${card.name} kann keine zusätzlichen Diener beschwören.`);
+          return `Keine Diener zum Beschwören verfügbar.`;
+        }
+        const desired = Math.max(1, toPositiveInteger(effect.count ?? 1));
+        if (!Array.isArray(player.board)) {
+          player.board = [];
+        }
+        const current = player.board.length;
+        const freeSlots = Math.max(0, duelConfig.boardLimit - current);
+        if (freeSlots <= 0) {
+          logDuel(`${player.name} hat keinen Platz für weitere Diener.`);
+          return `${player.name} hat keinen Platz für weitere Diener.`;
+        }
+        const actual = Math.min(desired, freeSlots);
+        const summoned = [];
+        for (let i = 0; i < actual; i += 1) {
+          const unit = createUnitInstance(template);
+          if (!unit) {
+            continue;
+          }
+          player.board.push(unit);
+          summoned.push(unit);
+        }
+        if (summoned.length === 0) {
+          logDuel(`${card.name} konnte keine Diener beschwören.`);
+          return `${player.name} konnte keine Diener beschwören.`;
+        }
+        const names = summoned.map((unit) => unit.name).join(", ");
+        logDuel(`${player.name} beschwört ${names}.`);
+        const summaryName = summoned.length === 1 ? summoned[0].name : `${summoned.length} Diener`;
+        return `Beschwört ${summaryName}.`;
+      }
+      case "healAllies": {
+        if (!player) {
+          return undefined;
+        }
+        let healedTotal = 0;
+        let affected = 0;
+        (player.board ?? []).forEach((unit) => {
+          if (!unit || unit.health <= 0) {
+            return;
+          }
+          const healed = healUnit(unit, amount);
+          if (healed > 0) {
+            healedTotal += healed;
+            affected += 1;
+            logDuel(`${card.name} heilt ${player.name}s ${unit.name} um ${healed} Leben (${unit.health}/${unit.maxHealth}).`);
+          }
+        });
+        if (affected > 0) {
+          return `Heilt ${affected === 1 ? "einen Diener" : `${affected} Diener`} um insgesamt ${healedTotal} Leben.`;
+        }
+        logDuel(`${card.name} findet keine verwundeten Verbündeten.`);
+        return `${player.name} hat keine verletzten Diener.`;
+      }
+      case "buffAlliesAttack": {
+        if (!player) {
+          return undefined;
+        }
+        let buffed = 0;
+        (player.board ?? []).forEach((unit) => {
+          if (!unit || unit.health <= 0) {
+            return;
+          }
+          const currentAttack = Number(unit.attack);
+          const safeAttack = Number.isFinite(currentAttack) ? currentAttack : 0;
+          unit.attack = Math.max(0, safeAttack + amount);
+          buffed += 1;
+          logDuel(`${card.name} erhöht ${player.name}s ${unit.name} auf ${unit.attack} Schaden.`);
+        });
+        if (buffed > 0) {
+          return `Erhöht den Schaden von ${buffed} Diener${buffed === 1 ? "" : "n"} um ${amount}.`;
+        }
+        logDuel(`${card.name} verpufft – es sind keine Diener im Spiel.`);
+        return `${player.name} hat keine Diener im Spiel.`;
+      }
+      case "grantExtraAttack": {
+        if (target?.type !== "unit") {
+          logDuel(`${card.name} benötigt einen verbündeten Diener als Ziel.`);
+          return `Keine Wirkung – es wurde kein Diener gewählt.`;
+        }
+        const allyInfo = findUnit(target.playerIndex, target.unitId);
+        const allyUnit = allyInfo.unit;
+        const owner = allyInfo.player;
+        if (!allyUnit || !owner) {
+          logDuel(`${card.name} findet kein gültiges Verbündeten-Ziel.`);
+          return `Keine Wirkung – das Ziel ist nicht mehr im Spiel.`;
+        }
+        allyUnit.extraAttacks = Math.max(0, allyUnit.extraAttacks ?? 0) + 1;
+        allyUnit.exhausted = false;
+        allyUnit.hasAttacked = false;
+        logDuel(`${card.name} erfrischt ${owner.name}s ${allyUnit.name} für einen weiteren Angriff.`);
+        return `${allyUnit.name} darf erneut angreifen.`;
+      }
+      case "stun": {
+        if (target?.type !== "unit") {
+          logDuel(`${card.name} benötigt einen gegnerischen Diener als Ziel.`);
+          return `Keine Wirkung – es wurde kein gegnerischer Diener gewählt.`;
+        }
+        const enemyInfo = findUnit(target.playerIndex, target.unitId);
+        const enemyUnit = enemyInfo.unit;
+        const owner = enemyInfo.player;
+        if (!enemyUnit || !owner) {
+          logDuel(`${card.name} findet sein Ziel nicht mehr.`);
+          return `Keine Wirkung – das Ziel ist nicht mehr im Spiel.`;
+        }
+        const duration = Math.max(1, toPositiveInteger(effect.duration ?? 1));
+        enemyUnit.stunnedTurns = Math.max(enemyUnit.stunnedTurns ?? 0, duration);
+        enemyUnit.exhausted = true;
+        enemyUnit.hasAttacked = true;
+        logDuel(`${card.name} lähmt ${owner.name}s ${enemyUnit.name} für ${duration} Zug${duration > 1 ? "e" : ""}.`);
+        return `${owner.name}s ${enemyUnit.name} ist für ${duration} Zug${duration > 1 ? "e" : ""} gelähmt.`;
+      }
+      case "drawCards": {
+        if (!player) {
+          return undefined;
+        }
+        const drawAmount = Math.max(1, toPositiveInteger(effect.amount ?? amount ?? 0));
+        const drawn = [];
+        for (let i = 0; i < drawAmount; i += 1) {
+          const pulled = drawCard(player);
+          if (pulled) {
+            drawn.push(pulled.name);
+          }
+        }
+        if (drawn.length > 0) {
+          const names = drawn.join(", ");
+          logDuel(`${player.name} zieht ${names}.`);
+          checkDeckDefeat(playerIndex);
+          return `Zieht ${drawn.length} Karte${drawn.length === 1 ? "" : "n"}.`;
+        }
+        logDuel(`${card.name} findet keine Karten mehr im Deck von ${player.name}.`);
+        checkDeckDefeat(playerIndex);
+        return `${player.name} hat keine Karten mehr zum Ziehen.`;
+      }
+      case "healAndFortifyAllies": {
+        if (!player) {
+          return undefined;
+        }
+        const healAmount = toPositiveInteger(effect.heal ?? amount ?? 0);
+        const barrierBonus = toPositiveInteger(effect.barrier ?? 0);
+        let healedTotal = 0;
+        let fortified = 0;
+        (player.board ?? []).forEach((unit) => {
+          if (!unit || unit.health <= 0) {
+            return;
+          }
+          if (healAmount > 0) {
+            const healed = healUnit(unit, healAmount);
+            if (healed > 0) {
+              healedTotal += healed;
+              logDuel(`${card.name} heilt ${player.name}s ${unit.name} um ${healed} Leben (${unit.health}/${unit.maxHealth}).`);
+            }
+          }
+          if (barrierBonus > 0) {
+            const granted = fortifyUnit(unit, barrierBonus);
+            if (granted > 0) {
+              fortified += 1;
+              logDuel(
+                `${card.name} stärkt ${player.name}s ${unit.name} um zusätzliche ${granted} Barriere (${unit.health}/${unit.maxHealth}).`
+              );
+            }
+          }
+        });
+        if (healedTotal > 0 || fortified > 0) {
+          if (fortified > 0 && healedTotal > 0) {
+            return `Heilt und stärkt ${fortified} Diener${fortified === 1 ? "" : ""}.`;
+          }
+          if (fortified > 0) {
+            return `Verleiht ${fortified} Diener${fortified === 1 ? "" : "n"} zusätzliche Barriere.`;
+          }
+          return `Heilt ${player.name}s Diener um insgesamt ${healedTotal} Leben.`;
+        }
+        logDuel(`${card.name} findet keine verletzten Diener zum Stärken.`);
+        return `${player.name} hat keine Diener zum Stärken.`;
+      }
+      default:
+        return undefined;
+    }
+  }
+
+  function chooseEnemyUnitForSpell(player) {
+    if (!player || !Array.isArray(player.board) || player.board.length === 0) {
+      return undefined;
+    }
+    let bulwarkUnit;
+    let weakestUnit;
+    player.board.forEach((unit) => {
+      if (!unit || unit.health <= 0) {
+        return;
+      }
+      if (unit.bulwark && !bulwarkUnit) {
+        bulwarkUnit = unit;
+      }
+      if (!weakestUnit || unit.health < weakestUnit.health) {
+        weakestUnit = unit;
+      }
+    });
+    const target = bulwarkUnit ?? weakestUnit;
+    if (!target) {
+      return undefined;
+    }
+    return { unit: target };
+  }
+
+  function toPositiveInteger(value) {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) {
+      return 0;
+    }
+    return Math.max(0, Math.floor(numeric));
+  }
+
+  function applyDamageToUnit(playerIndex, unit, amount) {
+    if (!unit) {
+      return { actual: 0, destroyed: false };
+    }
+    const player = duelState.players[playerIndex];
+    if (!player) {
+      return { actual: 0, destroyed: false };
+    }
+    const damage = toPositiveInteger(amount);
+    if (damage <= 0) {
+      return { actual: 0, destroyed: false };
+    }
+    const currentHealth = Number(unit.health);
+    if (!Number.isFinite(currentHealth) || currentHealth <= 0) {
+      return { actual: 0, destroyed: false };
+    }
+    const actual = Math.min(currentHealth, damage);
+    if (actual <= 0) {
+      return { actual: 0, destroyed: false };
+    }
+    const remaining = Math.max(0, currentHealth - actual);
+    unit.health = remaining;
+    return { actual, destroyed: remaining <= 0 };
+  }
+
+  function removeUnit(playerIndex, targetUnit) {
+    const player = duelState.players[playerIndex];
+    if (!player || !Array.isArray(player.board)) {
+      return;
+    }
+    const index = player.board.indexOf(targetUnit);
+    if (index >= 0) {
+      player.board.splice(index, 1);
+    }
+  }
+
+  function applyHeroDamage(playerIndex, amount) {
+    const player = duelState.players[playerIndex];
+    if (!player) {
+      return { actual: 0, defeated: false };
+    }
+    const damage = toPositiveInteger(amount);
+    if (damage <= 0) {
+      return { actual: 0, defeated: false };
+    }
+    const currentHealth = Number(player.health);
+    if (!Number.isFinite(currentHealth) || currentHealth <= 0) {
+      return { actual: 0, defeated: false };
+    }
+    const actual = Math.min(currentHealth, damage);
+    if (actual <= 0) {
+      return { actual: 0, defeated: false };
+    }
+    const remaining = Math.max(0, currentHealth - actual);
+    player.health = remaining;
+    return { actual, defeated: remaining <= 0 };
+  }
+
+  function healHero(playerIndex, amount) {
+    const player = duelState.players[playerIndex];
+    if (!player) {
+      return 0;
+    }
+    const healing = toPositiveInteger(amount);
+    if (healing <= 0) {
+      return 0;
+    }
+    const currentHealth = Number(player.health);
+    const safeHealth = Number.isFinite(currentHealth) ? currentHealth : 0;
+    const missing = Math.max(0, duelConfig.startingHealth - safeHealth);
+    const actual = Math.min(missing, healing);
+    if (actual <= 0) {
+      return 0;
+    }
+    player.health = Math.min(duelConfig.startingHealth, safeHealth + actual);
+    return actual;
+  }
+
+  function healUnit(unit, amount) {
+    if (!unit) {
+      return 0;
+    }
+    const healing = toPositiveInteger(amount);
+    if (healing <= 0) {
+      return 0;
+    }
+    const currentHealth = Number(unit.health);
+    const maxHealth = Number(unit.maxHealth);
+    if (!Number.isFinite(maxHealth)) {
+      return 0;
+    }
+    const safeHealth = Number.isFinite(currentHealth) ? currentHealth : maxHealth;
+    const missing = Math.max(0, maxHealth - safeHealth);
+    const actual = Math.min(missing, healing);
+    if (actual <= 0) {
+      return 0;
+    }
+    unit.health = Math.min(maxHealth, safeHealth + actual);
+    return actual;
+  }
+
+  function fortifyUnit(unit, amount) {
+    if (!unit) {
+      return 0;
+    }
+    const bonus = toPositiveInteger(amount);
+    if (bonus <= 0) {
+      return 0;
+    }
+    const currentMax = Number(unit.maxHealth);
+    const safeMax = Number.isFinite(currentMax) ? Math.max(1, currentMax) : Math.max(1, Number(unit.health) || 1);
+    unit.maxHealth = safeMax + bonus;
+    const currentHealth = Number(unit.health);
+    const safeHealth = Number.isFinite(currentHealth) ? Math.max(0, currentHealth) : safeMax;
+    unit.health = Math.min(unit.maxHealth, safeHealth + bonus);
+    return bonus;
+  }
+
+  function healAlly(playerIndex, amount, sourceName) {
+    const player = duelState.players[playerIndex];
+    if (!player) {
+      return {};
+    }
+    let targetUnit;
+    let missingMost = 0;
+    player.board.forEach((unit) => {
+      if (!unit) {
+        return;
+      }
+      const missing = unit.maxHealth - unit.health;
+      if (missing > missingMost) {
+        missingMost = missing;
+        targetUnit = unit;
+      }
+    });
+    if (targetUnit && missingMost > 0) {
+      const healed = healUnit(targetUnit, amount);
+      if (healed > 0) {
+        logDuel(`${sourceName} heilt ${player.name}s ${targetUnit.name} um ${healed} Leben (${targetUnit.health}/${targetUnit.maxHealth}).`);
+        return { description: `Stärkt ${targetUnit.name} um ${healed} Leben.` };
+      }
+    }
+    const healedHero = healHero(playerIndex, amount);
+    if (healedHero > 0) {
+      logDuel(`${sourceName} heilt ${player.name} um ${healedHero} Lebenspunkte (${player.health} LP).`);
+      return { description: `Heilt ${player.name} um ${healedHero} Lebenspunkte.` };
+    }
+    logDuel(`${sourceName} hat keine Wirkung – alle Verbündeten sind bei voller Gesundheit.`);
+    return { description: `Keine Wirkung – alles ist bereits geheilt.` };
+  }
+
+  function checkDeckDefeat(playerIndex) {
+    if (duelState.status !== "active") {
+      return false;
+    }
+    const player = duelState.players[playerIndex];
+    if (!player) {
+      return false;
+    }
+    const deckCount = player.deck?.length ?? 0;
+    const handCount = player.hand?.length ?? 0;
+    const boardCount = player.board?.length ?? 0;
+    if (deckCount + handCount + boardCount > 0) {
+      return false;
+    }
+    const opponentIndex = (playerIndex + 1) % duelState.players.length;
+    const opponentName = duelState.players[opponentIndex]?.name ?? "Der Gegner";
+    finishDuel(opponentIndex, `${player.name} hat keine Karten mehr – ${opponentName} gewinnt die Arena!`);
+    return true;
+  }
+
+  function finishDuel(winnerIndex, message) {
+    if (duelState.status === "finished") {
+      return;
+    }
+    resetInteractionState();
+    duelState.status = "finished";
+    duelState.winner = winnerIndex;
+    if (message) {
+      logDuel(message);
+    } else {
+      renderDuelLog();
+    }
+    renderDuel();
+  }
+
+  function drawCard(player) {
+    if (!player || !player.deck || player.deck.length === 0) {
+      return undefined;
+    }
+    const cardId = player.deck.pop();
+    if (!cardId) {
+      return undefined;
+    }
+    player.hand.push(cardId);
+    return itemsById.get(cardId);
+  }
+
+  function renderDuel() {
+    if (dom.duelPlayers && dom.duelPlayers.length > 0) {
+      dom.duelPlayers.forEach((entry, index) => {
+        const player = duelState.players[index] ?? createIdlePlayerState(duelDefaultNames[index] ?? `Sammler ${index + 1}`);
+        if (entry.name) {
+          entry.name.textContent = player.name;
+        }
+        if (entry.status) {
+          entry.status.textContent = getPlayerStatusLabel(player, index);
+        }
+        if (entry.health) {
+          entry.health.textContent = String(player.health);
+        }
+        if (entry.deck) {
+          entry.deck.textContent = String(player.deck ? player.deck.length : 0);
+        }
+        if (entry.handCount) {
+          entry.handCount.textContent = String(player.hand ? player.hand.length : 0);
+        }
+        if (entry.boardCount) {
+          entry.boardCount.textContent = String(player.board ? player.board.length : 0);
+        }
+        if (entry.root) {
+          const isActive = duelState.status === "active" && duelState.activePlayer === index;
+          const isWinner = duelState.status === "finished" && duelState.winner === index;
+          const isDefeated = duelState.status === "finished" && duelState.winner != null && duelState.winner !== index;
+          entry.root.classList.toggle("is-active", isActive);
+          entry.root.classList.toggle("is-winner", isWinner);
+          entry.root.classList.toggle("is-defeated", isDefeated);
+        }
+        renderPlayerHero(entry.hero, player, index);
+        renderCrystals(entry.crystals, player);
+        renderPlayerBoard(entry.board, player, index);
+        renderPlayerHand(entry.hand, player, index);
+      });
+    }
+
+    if (dom.duelRound) {
+      if (duelState.turnCounter === 0) {
+        dom.duelRound.textContent = "–";
+      } else {
+        const round = Math.max(1, Math.ceil(duelState.turnCounter / duelState.players.length));
+        dom.duelRound.textContent = String(round);
+      }
+    }
+
+    if (dom.duelActive) {
+      if (duelState.status === "finished") {
+        const winnerName =
+          typeof duelState.winner === "number" ? duelState.players[duelState.winner]?.name : undefined;
+        dom.duelActive.textContent = winnerName ? `${winnerName} (Sieg)` : "–";
+      } else if (duelState.status === "active") {
+        const current = duelState.players[duelState.activePlayer];
+        dom.duelActive.textContent = current ? current.name : "–";
+      } else {
+        dom.duelActive.textContent = "–";
+      }
+    }
+
+    if (dom.duelStart) {
+      dom.duelStart.textContent = duelState.status === "idle" ? "Match starten" : "Neu starten";
+    }
+    if (dom.duelEndTurn) {
+      dom.duelEndTurn.disabled = duelState.status !== "active";
+    }
+
+    renderDeckList();
+    renderTargetPanel();
+    renderDuelLog();
+  }
+
+  function getPlayerStatusLabel(player, index) {
+    if (duelState.status === "finished") {
+      return duelState.winner === index ? "Sieg" : "Besiegt";
+    }
+    if (duelState.status === "active") {
+      return duelState.activePlayer === index ? "Am Zug" : "Wartet";
+    }
+    return "Bereit";
+  }
+
+  function renderCrystals(container, player) {
+    if (!container) {
+      return;
+    }
+    const totalSlots = duelConfig.maxCrystals;
+    container.innerHTML = "";
+    for (let i = 0; i < totalSlots; i += 1) {
+      const crystal = document.createElement("span");
+      crystal.className = "duel-crystal";
+      if (player && i < player.maxCrystals) {
+        crystal.classList.add("is-active");
+      }
+      if (player && i < player.crystals) {
+        crystal.classList.add("is-filled");
+      }
+      container.append(crystal);
+    }
+    const available = player ? player.crystals : 0;
+    const max = player ? player.maxCrystals : 0;
+    container.setAttribute(
+      "aria-label",
+      `${available} von ${max} Lebensessenz-Kristallen verfügbar`
+    );
+  }
+
+  function renderPlayerHero(element, player, playerIndex) {
+    if (!element) {
+      return;
+    }
+    const name = player?.name ?? `Sammler ${playerIndex + 1}`;
+    element.dataset.playerIndex = String(playerIndex);
+    const healthValue = element.querySelector(".duel-health-value");
+    if (healthValue) {
+      healthValue.textContent = String(player?.health ?? 0);
+    }
+    const targetable = isTargetKeyActive({ type: "hero", playerIndex });
+    element.classList.toggle("is-targetable", targetable);
+    element.disabled = !targetable;
+    element.setAttribute("aria-label", `${name} mit ${player?.health ?? 0} Lebenspunkten`);
+  }
+
+  function renderPlayerBoard(container, player, playerIndex) {
+    if (!container) {
+      return;
+    }
+    container.innerHTML = "";
+    const board = player?.board ?? [];
+    if (board.length === 0) {
+      const placeholder = document.createElement("p");
+      placeholder.className = "duel-board-empty";
+      if (duelState.status === "finished") {
+        placeholder.textContent = "Keine Karten mehr im Spiel.";
+      } else if (duelState.status === "active" && duelState.activePlayer === playerIndex) {
+        placeholder.textContent = "Keine Karten im Spiel – beschwöre neue Verbündete.";
+      } else {
+        placeholder.textContent = "Noch keine Karten im Spiel.";
+      }
+      container.append(placeholder);
+      return;
+    }
+
+    board.forEach((unit) => {
+      const card = document.createElement("article");
+      card.className = "duel-board-card";
+      if (unit?.instanceId) {
+        card.dataset.unitId = unit.instanceId;
+      }
+      if (unit?.bulwark) {
+        card.classList.add("is-bulwark");
+      }
+      if (unit?.exhausted) {
+        card.classList.add("is-exhausted");
+      }
+
+      const isTargetable = isTargetKeyActive({ type: "unit", playerIndex, unitId: unit?.instanceId });
+      const isSelectedAttacker =
+        duelInteraction.mode === "attack" &&
+        duelInteraction.sourcePlayer === playerIndex &&
+        duelInteraction.sourceUnitId === unit?.instanceId;
+      const canAttack =
+        duelState.status === "active" &&
+        duelState.activePlayer === playerIndex &&
+        duelInteraction.mode !== "spell" &&
+        unit &&
+        unit.health > 0 &&
+        !unit.exhausted &&
+        (unit.attack ?? 0) > 0;
+
+      if (canAttack) {
+        card.classList.add("is-selectable");
+      }
+      if (isSelectedAttacker) {
+        card.classList.add("is-selected");
+      }
+      if (isTargetable) {
+        card.classList.add("is-targetable");
+      }
+
+      const header = document.createElement("header");
+      header.className = "duel-board-card-header";
+      const name = document.createElement("strong");
+      name.textContent = unit?.name ?? "Unbekannt";
+      header.append(name);
+      if (unit?.bulwark) {
+        const tag = document.createElement("span");
+        tag.className = "duel-tag";
+        tag.textContent = "Bollwerk";
+        header.append(tag);
+      }
+
+      const stats = document.createElement("div");
+      stats.className = "duel-board-card-stats";
+      const attackValue = Math.max(0, unit?.attack ?? 0);
+      const healthValue = Math.max(0, unit?.health ?? 0);
+      const maxValue = Math.max(0, unit?.maxHealth ?? healthValue);
+      stats.innerHTML = `
+        <span><em>Angriff</em><strong>${attackValue}</strong></span>
+        <span><em>Leben</em><strong>${healthValue}/${maxValue}</strong></span>
+      `;
+
+      card.append(header, stats);
+      container.append(card);
+    });
+  }
+
+  function renderPlayerHand(container, player, playerIndex) {
+    if (!container) {
+      return;
+    }
+    container.innerHTML = "";
+    const hand = player?.hand ?? [];
+    if (hand.length === 0) {
+      const placeholder = document.createElement("p");
+      placeholder.className = "duel-hand-empty";
+      if (duelState.status === "finished") {
+        placeholder.textContent = "Match abgeschlossen.";
+      } else if (duelState.status === "active" && duelState.activePlayer === playerIndex) {
+        placeholder.textContent = "Keine Karten spielbar – ziehe nach oder beende den Zug.";
+      } else {
+        placeholder.textContent = "Noch keine Karten auf der Hand.";
+      }
+      container.append(placeholder);
+      return;
+    }
+
+    hand.forEach((cardId, index) => {
+      const item = itemsById.get(cardId);
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "duel-card";
+      button.dataset.playerIndex = String(playerIndex);
+      button.dataset.cardIndex = String(index);
+      button.setAttribute("role", "listitem");
+
+      if (item?.cardType === "spell") {
+        button.classList.add("is-spell");
+      }
+
+      const boardCount = player?.board?.length ?? 0;
+      const boardFull = item?.cardType !== "spell" && boardCount >= duelConfig.boardLimit;
+      const effectiveCost = item ? getEffectiveCardCost(item, playerIndex) : Number.POSITIVE_INFINITY;
+      const playable =
+        duelState.status === "active" &&
+        duelState.activePlayer === playerIndex &&
+        item &&
+        effectiveCost <= player.crystals &&
+        !boardFull;
+      if (!playable) {
+        button.disabled = true;
+      } else {
+        button.classList.add("is-playable");
+      }
+
+      const pendingSpell = duelInteraction.mode === "spell" ? duelInteraction.pendingSpell : undefined;
+      if (pendingSpell) {
+        const isPending = pendingSpell.playerIndex === playerIndex && pendingSpell.cardIndex === index;
+        if (isPending) {
+          button.classList.add("is-selected");
+          button.disabled = false;
+        } else {
+          button.disabled = true;
+          button.classList.remove("is-playable");
+        }
+      }
+
+      const cost = document.createElement("span");
+      cost.className = "duel-card-cost";
+      cost.textContent = Number.isFinite(effectiveCost) ? String(effectiveCost) : item ? String(item.cost) : "?";
+
+      const body = document.createElement("div");
+      body.className = "duel-card-body";
+      const title = document.createElement("strong");
+      title.textContent = item ? item.name : "Unbekannt";
+      body.append(title);
+
+      const meta = document.createElement("span");
+      meta.className = "duel-card-meta";
+      if (item) {
+        const typeParts = [];
+        if (item.cardType === "spell") {
+          typeParts.push("Zauber");
+        } else {
+          typeParts.push("Einheit");
+          typeParts.push(`${item.damage} Angriff`);
+          typeParts.push(`${item.health} Leben`);
+          if (Array.isArray(item.abilities) && item.abilities.includes("bulwark")) {
+            typeParts.push("Bollwerk");
+          }
+        }
+        meta.textContent = typeParts.join(" · ");
+        const tooltipParts = [`Kosten ${item.cost}`];
+        if (item.cardType === "spell" && item.text) {
+          tooltipParts.push(item.text);
+        } else if (item.cardType === "unit") {
+          tooltipParts.push(`${item.damage} Angriff`);
+          tooltipParts.push(`${item.health} Leben`);
+          if (Array.isArray(item.abilities) && item.abilities.includes("bulwark")) {
+            tooltipParts.push("Bollwerk");
+          }
+        }
+        if (boardFull && item.cardType !== "spell") {
+          tooltipParts.push("Kein Platz auf dem Feld");
+        }
+        button.title = `${item.name} – ${tooltipParts.join(", ")}`;
+      } else {
+        meta.textContent = "Unbekannte Karte";
+        button.title = "Unbekannte Karte";
+      }
+
+      body.append(meta);
+
+      if (item?.text) {
+        const text = document.createElement("span");
+        text.className = "duel-card-text";
+        text.textContent = item.text;
+        body.append(text);
+      }
+
+      button.append(cost, body);
+      container.append(button);
+    });
+  }
+
+  function describeTarget(target) {
+    if (!target) {
+      return "Ziel";
+    }
+    if (target.type === "hero") {
+      const player = duelState.players[target.playerIndex];
+      if (!player) {
+        return "Held";
+      }
+      const health = Math.max(0, player.health ?? 0);
+      return `${player.name} – Held (${health} LP)`;
+    }
+    if (target.type === "unit") {
+      const { player, unit } = findUnit(target.playerIndex, target.unitId);
+      if (!player || !unit) {
+        return "Feldkarte";
+      }
+      const attack = Math.max(0, unit.attack ?? 0);
+      const currentHealth = Math.max(0, unit.health ?? 0);
+      const maxHealth = Math.max(currentHealth, unit.maxHealth ?? currentHealth);
+      return `${player.name}: ${unit.name} (${attack} ANG · ${currentHealth}/${maxHealth} LP)`;
+    }
+    return "Ziel";
+  }
+
+  function summarizeDeckCards(cards) {
+    const counts = new Map();
+    cards.forEach((id) => {
+      if (!id) {
+        return;
+      }
+      counts.set(id, (counts.get(id) ?? 0) + 1);
+    });
+    const entries = [];
+    counts.forEach((count, id) => {
+      const item = itemsById.get(id);
+      if (item) {
+        entries.push({ item, count });
+      }
+    });
+    entries.sort((a, b) => {
+      const costDiff = (a.item.cost ?? 0) - (b.item.cost ?? 0);
+      if (costDiff !== 0) {
+        return costDiff;
+      }
+      const rarityDiff = (rarityScore[a.item.rarity] ?? 0) - (rarityScore[b.item.rarity] ?? 0);
+      if (rarityDiff !== 0) {
+        return rarityDiff;
+      }
+      return a.item.name.localeCompare(b.item.name, "de");
+    });
+    return entries;
+  }
+
+  function renderDeckList() {
+    if (!dom.duelDecklist) {
+      return;
+    }
+    const container = dom.duelDecklist;
+    container.innerHTML = "";
+    const players = duelState.players ?? [];
+    let hasContent = false;
+    players.forEach((player, index) => {
+      const section = document.createElement("section");
+      section.className = "duel-decklist-section";
+
+      const heading = document.createElement("h4");
+      heading.textContent = player?.name ?? `Sammler ${index + 1}`;
+      section.append(heading);
+
+      const activeDeckCards =
+        player?.startingDeck && player.startingDeck.length > 0
+          ? player.startingDeck
+          : getActiveDeckCardList();
+      const total = activeDeckCards.length;
+      const uniqueCount = new Set(activeDeckCards).size;
+      const resolvedDeckName = sanitizeDeckName(
+        (player?.deckName && player.deckName.length > 0 ? player.deckName : collectionState.deck?.name) ?? ""
+      );
+      if (resolvedDeckName) {
+        const deckTitle = document.createElement("p");
+        deckTitle.className = "duel-decklist-label";
+        deckTitle.textContent = `Deck: ${resolvedDeckName}`;
+        section.append(deckTitle);
+      }
+      const summary = document.createElement("p");
+      summary.className = "duel-decklist-summary";
+      if (total === 0) {
+        summary.textContent = "Kein aktives Deck – baue eines in der Deck-Werkstatt.";
+      } else {
+        summary.textContent = `${total}/${duelConfig.deckSize} Karten · ${uniqueCount} einzigartig`;
+        hasContent = true;
+      }
+      section.append(summary);
+
+      const list = document.createElement("ul");
+      list.className = "duel-decklist-items";
+      const entries = summarizeDeckCards(activeDeckCards);
+      if (entries.length === 0) {
+        const empty = document.createElement("li");
+        empty.className = "duel-decklist-empty";
+        empty.textContent = "Sammle Karten und speichere dein Deck, um die Arena zu betreten.";
+        list.append(empty);
+      } else {
+        entries.forEach(({ item, count }) => {
+          const row = document.createElement("li");
+          row.className = "duel-decklist-entry";
+
+          const countBadge = document.createElement("span");
+          countBadge.className = "duel-decklist-count";
+          countBadge.textContent = `×${count}`;
+
+          const name = document.createElement("span");
+          name.className = "duel-decklist-name";
+          name.textContent = item.name;
+
+          const meta = document.createElement("span");
+          meta.className = "duel-decklist-meta";
+          const metaParts = [`${item.cost} Kosten`];
+          if (item.cardType === "spell") {
+            metaParts.push("Zauber");
+            if (item.effect?.amount && typeof item.effect.amount === "number") {
+              switch (item.effect.type) {
+                case "directDamage":
+                  metaParts.push(`${item.effect.amount} Schaden am Helden`);
+                  break;
+                case "enemyUnitDamage":
+                  metaParts.push(`${item.effect.amount} Schaden an Einheiten`);
+                  break;
+                case "damageAllEnemies":
+                  metaParts.push(`${item.effect.amount} Flächenschaden`);
+                  break;
+                case "healHero":
+                  metaParts.push(`Heilung ${item.effect.amount}`);
+                  break;
+                case "allyHeal":
+                  metaParts.push(`Heilung ${item.effect.amount}`);
+                  break;
+                default:
+                  break;
+              }
+            }
+          } else {
+            metaParts.push(`${item.damage} Angriff`);
+            metaParts.push(`${item.health} Leben`);
+            if (Array.isArray(item.abilities) && item.abilities.includes("bulwark")) {
+              metaParts.push("Bollwerk");
+            }
+          }
+          meta.textContent = metaParts.join(" · ");
+
+          row.append(countBadge, name, meta);
+          list.append(row);
+        });
+      }
+
+      section.append(list);
+      container.append(section);
+    });
+
+    if (!container.hasChildNodes()) {
+      const placeholder = document.createElement("p");
+      placeholder.className = "duel-decklist-empty";
+      placeholder.textContent = "Starte ein Match, um deine Deckliste zu sehen.";
+      container.append(placeholder);
+    }
+
+    if (dom.duelDecklistRoot) {
+      dom.duelDecklistRoot.classList.toggle("is-empty", !hasContent);
+      if (!hasContent) {
+        dom.duelDecklistRoot.open = false;
+      }
+    }
+  }
+
+  function renderTargetPanel() {
+    if (!dom.duelTargetPanel) {
+      return;
+    }
+    const isInteractiveMode = duelInteraction.mode === "attack" || duelInteraction.mode === "spell";
+    const targets = duelInteraction.targets ?? [];
+    if (!isInteractiveMode || targets.length === 0) {
+      dom.duelTargetPanel.classList.remove("is-visible");
+      if (dom.duelTargetList) {
+        dom.duelTargetList.innerHTML = "";
+      }
+      if (dom.duelTargetMessage) {
+        dom.duelTargetMessage.textContent =
+          "Wähle eine Karte deiner Seite, um einen Angriff oder Zauber zu beginnen.";
+      }
+      if (dom.duelTargetCancel) {
+        dom.duelTargetCancel.hidden = true;
+        dom.duelTargetCancel.disabled = true;
+      }
+      return;
+    }
+
+    dom.duelTargetPanel.classList.add("is-visible");
+
+    const heroAvailable = targets.some((target) => target.type === "hero");
+    const unitAvailable = targets.some((target) => target.type === "unit");
+    let message;
+    if (duelInteraction.mode === "attack") {
+      if (heroAvailable && unitAvailable) {
+        message = "Wähle das Ziel für deinen Angriff – Held oder Feldkarte.";
+      } else if (heroAvailable) {
+        message = "Wähle den gegnerischen Helden als Ziel deines Angriffs.";
+      } else {
+        message = "Wähle die gegnerische Feldkarte, die angegriffen werden soll.";
+      }
+    } else if (heroAvailable && unitAvailable) {
+      message = "Wähle das Ziel für deinen Zauber.";
+    } else if (heroAvailable) {
+      message = "Wähle den Helden, der vom Zauber betroffen sein soll.";
+    } else {
+      message = "Wähle die Karte, auf die der Zauber gewirkt wird.";
+    }
+    if (dom.duelTargetMessage) {
+      dom.duelTargetMessage.textContent = message;
+    }
+
+    if (dom.duelTargetList) {
+      dom.duelTargetList.innerHTML = "";
+      targets.forEach((target) => {
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = "duel-target-option";
+        button.setAttribute("role", "listitem");
+        button.textContent = describeTarget(target);
+        button.addEventListener("click", () => {
+          if (duelInteraction.mode === "attack") {
+            resolveAttackTarget(target);
+          } else if (duelInteraction.mode === "spell") {
+            resolvePendingSpell(target);
+          }
+        });
+        dom.duelTargetList.append(button);
+      });
+    }
+
+    if (dom.duelTargetCancel) {
+      dom.duelTargetCancel.hidden = false;
+      dom.duelTargetCancel.disabled = false;
+      dom.duelTargetCancel.textContent =
+        duelInteraction.mode === "spell" ? "Zauber abbrechen" : "Angriff abbrechen";
+    }
+  }
+
+  function logDuel(message) {
+    duelState.log.push(message);
+    if (duelState.log.length > duelConfig.logLimit) {
+      duelState.log.splice(0, duelState.log.length - duelConfig.logLimit);
+    }
+    renderDuelLog();
+  }
+
+  function renderDuelLog() {
+    if (!dom.duelLog) {
+      return;
+    }
+    dom.duelLog.innerHTML = "";
+    if (duelState.log.length === 0) {
+      const entry = document.createElement("li");
+      entry.className = "duel-log-empty";
+      entry.textContent = "Noch keine Aktionen – starte ein Match!";
+      dom.duelLog.append(entry);
+      return;
+    }
+    duelState.log.forEach((message) => {
+      const entry = document.createElement("li");
+      entry.textContent = message;
+      dom.duelLog.append(entry);
+    });
+    dom.duelLog.scrollTop = dom.duelLog.scrollHeight;
+  }
+
+  function setupPanelSlider() {
+    if (!sliderState.viewport || sliderState.panels.length === 0) {
+      return;
+    }
+
+    sliderState.navLinks.forEach((link) => {
+      link.addEventListener("click", (event) => {
+        event.preventDefault();
+        const targetId = link.dataset.panelTarget;
+        if (targetId) {
+          scrollToSection(targetId);
+        }
+      });
+    });
+
+    sliderState.viewport.addEventListener("scroll", onPanelViewportScroll, {
+      passive: true,
+    });
+
+    const hash = typeof window !== "undefined" ? window.location.hash.slice(1) : "";
+    const initialId =
+      (hash && sliderState.panels.find((panel) => panel.id === hash)?.id) ||
+      sliderState.panels[0].id;
+
+    setActivePanel(initialId, { updateHash: false, force: true });
+    scrollToSection(initialId, { immediate: true, updateHash: false });
+
+    window.addEventListener("resize", () => {
+      if (!sliderState.viewport || sliderState.panels.length === 0) {
+        return;
+      }
+      const targetId = activePanelId ?? sliderState.panels[0].id;
+      scrollToSection(targetId, { immediate: true, updateHash: false });
+    });
+  }
+
+  function onPanelViewportScroll() {
+    if (panelScrollRaf) {
+      return;
+    }
+    panelScrollRaf = window.requestAnimationFrame(syncActivePanelFromScroll);
+  }
+
+  function syncActivePanelFromScroll() {
+    panelScrollRaf = 0;
+    if (!sliderState.viewport || sliderState.panels.length === 0) {
+      return;
+    }
+    const viewport = sliderState.viewport;
+    const width = viewport.clientWidth;
+    if (width === 0) {
+      return;
+    }
+    const index = Math.round(viewport.scrollLeft / width);
+    const clampedIndex = Math.max(0, Math.min(sliderState.panels.length - 1, index));
+    const panel = sliderState.panels[clampedIndex];
+    if (panel && panel.id !== activePanelId) {
+      setActivePanel(panel.id);
+    }
+  }
+
+  function setActivePanel(id, options = {}) {
+    if (!id || sliderState.panels.length === 0) {
+      activePanelId = id;
+      return;
+    }
+    const { updateHash = true, force = false } = options;
+    if (!force && activePanelId === id) {
+      return;
+    }
+    activePanelId = id;
+    updateNavActive(id);
+    updatePanelVisibility(id);
+    if (
+      updateHash &&
+      typeof window !== "undefined" &&
+      window.history &&
+      typeof window.history.replaceState === "function"
+    ) {
+      window.history.replaceState(null, "", `#${id}`);
+    }
+  }
+
+  function updateNavActive(id) {
+    sliderState.navLinks.forEach((link) => {
+      const isActive = link.dataset.panelTarget === id;
+      link.classList.toggle("is-active", isActive);
+      if (isActive) {
+        link.setAttribute("aria-current", "page");
+      } else {
+        link.removeAttribute("aria-current");
+      }
+    });
+  }
+
+  function updatePanelVisibility(activeId) {
+    sliderState.panels.forEach((panel) => {
+      const isActive = panel.id === activeId;
+      panel.classList.toggle("is-active", isActive);
+      if (isActive) {
+        panel.removeAttribute("aria-hidden");
+      } else {
+        panel.setAttribute("aria-hidden", "true");
+      }
+    });
+  }
+
+  function scrollToSection(id, options = {}) {
+    if (!id) {
+      return;
+    }
+    if (sliderState.viewport && sliderState.panels.length > 0) {
+      const index = sliderState.panels.findIndex((panel) => panel.id === id);
+      if (index === -1) {
+        return;
+      }
+      const viewport = sliderState.viewport;
+      const offset = index * viewport.clientWidth;
+      const behavior = options.immediate ? "auto" : "smooth";
+      viewport.scrollTo({ left: offset, behavior });
+      setActivePanel(id, { updateHash: options.updateHash !== false });
+      return;
+    }
+    const section = document.getElementById(id);
+    if (section) {
+      section.scrollIntoView({ behavior: options.immediate ? "auto" : "smooth" });
+    }
+  }
+
+  function loadCollection() {
+    if (!supportsStorage) {
+      return { items: {} };
+    }
+    try {
+      const raw = window.localStorage.getItem(storageKeys.collection);
+      if (!raw) {
+        return { items: {} };
+      }
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== "object") {
+        return { items: {} };
+      }
+      if (!parsed.items || typeof parsed.items !== "object") {
+        parsed.items = {};
+      }
+      return parsed;
+    } catch (error) {
+      return { items: {} };
+    }
+  }
+
+  function saveCollection() {
+    if (!supportsStorage) {
+      return;
+    }
+    window.localStorage.setItem(storageKeys.collection, JSON.stringify(collectionState));
+  }
+
+  function loadLoginState() {
+    if (!supportsStorage) {
+      return { streak: 0, lastClaim: undefined };
+    }
+    try {
+      const raw = window.localStorage.getItem(storageKeys.login);
+      if (!raw) {
+        return { streak: 0, lastClaim: undefined };
+      }
+      const parsed = JSON.parse(raw);
+      return {
+        streak: parsed?.streak ?? 0,
+        lastClaim: parsed?.lastClaim,
+      };
+    } catch (error) {
+      return { streak: 0, lastClaim: undefined };
+    }
+  }
+
+  function saveLoginState() {
+    if (!supportsStorage) {
+      return;
+    }
+    window.localStorage.setItem(storageKeys.login, JSON.stringify(loginState));
+  }
+
+  function loadEventState() {
+    const defaultDuration = 1000 * 60 * 60 * 36; // 36 Stunden
+    if (!supportsStorage) {
+      return { endsAt: Date.now() + defaultDuration };
+    }
+    try {
+      const raw = window.localStorage.getItem(storageKeys.event);
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (parsed?.endsAt) {
+          return { endsAt: parsed.endsAt };
+        }
+      }
+    } catch (error) {
+      // ignore and create new state
+    }
+    const endsAt = Date.now() + defaultDuration;
+    window.localStorage.setItem(storageKeys.event, JSON.stringify({ endsAt }));
+    return { endsAt };
+  }
+
+  function isSameDay(a, b) {
+    return (
+      a.getFullYear() === b.getFullYear() &&
+      a.getMonth() === b.getMonth() &&
+      a.getDate() === b.getDate()
+    );
+  }
+
+  function isNextDay(a, b) {
+    const msPerDay = 1000 * 60 * 60 * 24;
+    const startOfA = new Date(a.getFullYear(), a.getMonth(), a.getDate()).getTime();
+    const startOfB = new Date(b.getFullYear(), b.getMonth(), b.getDate()).getTime();
+    const diff = Math.floor((startOfB - startOfA) / msPerDay);
+    return diff === 1;
+  }
+})();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,2183 @@
+:root {
+  --bg-0: #0e0b1a;
+  --bg-1: #17112b;
+  --bg-2: #241a43;
+  --text-primary: #f5f2ff;
+  --text-muted: rgba(245, 242, 255, 0.65);
+  --accent: #ff8b6a;
+  --accent-strong: #ffcf6a;
+  --accent-soft: rgba(255, 139, 106, 0.25);
+  --card: rgba(30, 24, 55, 0.88);
+  --card-strong: rgba(40, 30, 70, 0.95);
+  --border: rgba(255, 255, 255, 0.08);
+  --shadow: 0 30px 60px rgba(10, 4, 25, 0.45);
+  --radius-lg: 26px;
+  --radius-md: 18px;
+  --radius-sm: 12px;
+  --transition: 200ms ease;
+  --panel-height: clamp(360px, 60vh, 720px);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: "Space Grotesk", system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  background: radial-gradient(circle at 20% 20%, rgba(148, 92, 255, 0.1), transparent 40%),
+    radial-gradient(circle at 80% 0%, rgba(255, 139, 106, 0.15), transparent 50%),
+    linear-gradient(160deg, var(--bg-2), var(--bg-0));
+  color: var(--text-primary);
+  -webkit-font-smoothing: antialiased;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background-image: radial-gradient(rgba(255, 255, 255, 0.08) 1px, transparent 1px);
+  background-size: 60px 60px;
+  opacity: 0.25;
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+h1,
+ h2,
+ h3 {
+  font-family: "Press Start 2P", cursive;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+p {
+  margin: 0 0 1rem;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.sr-only {
+  position: absolute !important;
+  display: inline-block;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+.hero {
+  position: relative;
+  padding: 3rem clamp(1rem, 5vw, 5rem) 2.5rem;
+  overflow: hidden;
+}
+
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 75% 25%, rgba(255, 207, 106, 0.16), transparent 55%),
+    linear-gradient(120deg, rgba(255, 139, 106, 0.18), transparent 70%);
+  mix-blend-mode: screen;
+  pointer-events: none;
+}
+
+.top-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  backdrop-filter: blur(10px);
+  background: rgba(14, 11, 26, 0.5);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.75rem 1.5rem;
+  margin: 0 0 clamp(1.5rem, 4vw, 3rem);
+  box-shadow: var(--shadow);
+}
+
+.panel-nav {
+  margin-inline: 0;
+}
+
+.badge {
+  font-size: 0.7rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--accent-strong);
+}
+
+.nav-links {
+  display: flex;
+  gap: 1rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-links li a {
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  transition: background var(--transition), color var(--transition);
+}
+
+.nav-links li a:hover {
+  background: rgba(255, 207, 106, 0.12);
+  color: var(--accent-strong);
+}
+
+.nav-links li a.is-active {
+  background: rgba(255, 139, 106, 0.18);
+  color: var(--accent-strong);
+  box-shadow: 0 0 0 1px rgba(255, 207, 106, 0.35);
+}
+
+.hero-content {
+  max-width: 720px;
+  position: relative;
+  z-index: 1;
+}
+
+.hero h1 {
+  font-size: clamp(1.8rem, 4vw, 3.4rem);
+  line-height: 1.2;
+  color: var(--accent-strong);
+  text-shadow: 0 6px 25px rgba(255, 207, 106, 0.35);
+}
+
+.label {
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.lede {
+  font-size: 1.1rem;
+  color: rgba(245, 242, 255, 0.85);
+}
+
+.hero-actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2.5rem;
+}
+
+button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 0.85rem 1.8rem;
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+
+button:hover {
+  transform: translateY(-2px) scale(1.01);
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.primary {
+  background: linear-gradient(120deg, var(--accent) 0%, #ff6394 100%);
+  color: #190d2e;
+  box-shadow: 0 12px 30px rgba(255, 139, 106, 0.35);
+}
+
+.primary:hover:not(:disabled) {
+  box-shadow: 0 18px 36px rgba(255, 139, 106, 0.5);
+}
+
+.ghost {
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text-primary);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  gap: 1.2rem;
+}
+
+.meta-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  color: rgba(245, 242, 255, 0.55);
+  text-transform: uppercase;
+}
+
+.meta-value {
+  display: block;
+  margin-top: 0.35rem;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+main {
+  padding: 0 clamp(1rem, 4vw, 5rem) 6rem;
+}
+
+.panel-viewport {
+  position: relative;
+  overflow-x: auto;
+  overflow-y: visible;
+  scroll-behavior: smooth;
+  scroll-snap-type: x mandatory;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  background: rgba(18, 13, 36, 0.72);
+  box-shadow: var(--shadow);
+  margin: clamp(1.5rem, 4vw, 3rem) 0;
+  min-height: var(--panel-height);
+  height: auto;
+  scrollbar-width: none;
+}
+
+.panel-viewport::-webkit-scrollbar {
+  display: none;
+}
+
+.panel-track {
+  display: flex;
+  width: 100%;
+}
+
+.panel {
+  position: relative;
+  margin: 0;
+  padding: clamp(1.75rem, 4.5vw, 3rem);
+  background: var(--card);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  flex: 0 0 100%;
+  min-width: 100%;
+  min-height: var(--panel-height);
+  height: auto;
+  display: flex;
+  flex-direction: column;
+  overflow-x: hidden;
+  overflow-y: visible;
+  scroll-snap-align: start;
+}
+
+.panel::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(255, 139, 106, 0.12), transparent 60%);
+  opacity: 0.6;
+  pointer-events: none;
+  border-radius: inherit;
+}
+
+.panel > * {
+  position: relative;
+  z-index: 1;
+}
+
+.panel-header {
+  position: relative;
+  z-index: 1;
+  margin-bottom: clamp(1rem, 3vw, 1.75rem);
+}
+
+.loop-grid,
+.daily-grid,
+.pack-controls,
+.pack-results,
+.collection-stats,
+.set-progress-grid,
+.event-details,
+.roadmap-grid {
+  position: relative;
+  z-index: 1;
+}
+
+.loop-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.loop-grid article {
+  background: rgba(26, 19, 49, 0.8);
+  padding: 1.5rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.panel.daily,
+.panel.deckbuilder,
+.panel.multiplayer {
+  align-content: start;
+}
+
+.daily {
+  display: grid;
+  gap: 2rem;
+}
+
+.daily-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+}
+
+.login-card {
+  background: var(--card-strong);
+  padding: 2rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  display: grid;
+  gap: 1rem;
+}
+
+.streak {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.9rem;
+}
+
+.streak strong {
+  font-size: 2rem;
+  color: var(--accent-strong);
+}
+
+.login-status {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.next-reward {
+  background: rgba(255, 139, 106, 0.08);
+  padding: 1rem;
+  border-radius: var(--radius-md);
+  border: 1px dashed rgba(255, 139, 106, 0.5);
+  font-size: 0.85rem;
+  color: rgba(255, 217, 183, 0.85);
+}
+
+.reward-preview {
+  background: rgba(22, 16, 41, 0.9);
+  padding: 2rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  min-height: 260px;
+}
+
+.reward-display {
+  background: rgba(13, 9, 27, 0.9);
+  border-radius: 18px;
+  padding: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: inset 0 0 35px rgba(255, 139, 106, 0.07);
+  min-height: 120px;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  color: rgba(255, 214, 224, 0.9);
+  font-weight: 600;
+}
+
+.pack-controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, auto));
+  gap: 1rem;
+  align-items: center;
+  background: rgba(22, 16, 41, 0.7);
+  padding: 1.5rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.pack-controls label {
+  font-weight: 600;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.pack-controls select {
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text-primary);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 999px;
+  padding: 0.75rem 1rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+}
+
+.pack-results {
+  margin-top: 2rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.pack-results .card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.2rem;
+}
+
+.card {
+  background: rgba(11, 7, 22, 0.9);
+  border-radius: 22px;
+  padding: 1rem;
+  border: 2px solid rgba(255, 255, 255, 0.08);
+  display: grid;
+  grid-template-rows: auto 1fr;
+  gap: 1rem;
+  position: relative;
+  overflow: hidden;
+  transform-origin: center;
+  animation: pop 450ms ease-out;
+}
+
+.card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.card--full-art {
+  padding: 0;
+  background: none;
+  border: 2px solid transparent;
+  border-radius: 22px;
+  box-shadow: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  overflow: visible;
+  width: min(100%, 320px);
+  margin-inline: auto;
+}
+
+.card--full-art::after {
+  display: none;
+}
+
+.card-full-art {
+  position: relative;
+  margin: 0;
+  border-radius: 22px;
+  overflow: hidden;
+  background: rgba(10, 7, 22, 0.92);
+  box-shadow: 0 22px 40px rgba(8, 4, 20, 0.55);
+  width: 100%;
+}
+
+.card--full-art .card-full-art img {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: contain;
+  background: rgba(7, 5, 14, 0.9);
+}
+
+.card-qty--overlay {
+  position: absolute;
+  bottom: 0.85rem;
+  right: 0.85rem;
+  background: rgba(10, 8, 20, 0.75);
+  border-radius: 999px;
+  padding: 0.35rem 0.65rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.card-flag--overlay {
+  position: absolute;
+  top: 0.85rem;
+  left: 0.85rem;
+  z-index: 2;
+}
+
+.card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(130deg, rgba(255, 255, 255, 0.18), transparent 60%);
+  opacity: 0;
+  transition: opacity 300ms ease;
+  z-index: 0;
+}
+
+.card:hover::after {
+  opacity: 0.9;
+}
+
+.card.is-unowned {
+  opacity: 0.55;
+  filter: saturate(0.4);
+  border-style: dashed;
+  border-color: rgba(255, 255, 255, 0.14);
+}
+
+.card.is-unowned strong,
+.card.is-unowned .card-rarity,
+.card.is-unowned .card-type,
+.card.is-unowned .card-set {
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.card.is-unowned .card-qty {
+  display: none;
+}
+
+.card strong {
+  font-size: 1rem;
+  text-transform: uppercase;
+}
+
+.card .card-rarity {
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.62);
+}
+
+.card-illustration {
+  position: relative;
+  border-radius: 18px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.04);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06), 0 18px 32px rgba(8, 4, 20, 0.45);
+  aspect-ratio: 3 / 4;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.card-illustration img {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: contain;
+  object-position: center;
+}
+
+.card-content {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.card .card-set {
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.5);
+  margin: 0;
+}
+
+.card-type {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.card-text {
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.75);
+  margin: 0;
+}
+
+.card-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.card-stat {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: rgba(12, 10, 24, 0.65);
+  border-radius: 999px;
+  padding: 0.35rem 0.7rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: rgba(255, 255, 255, 0.85);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.card-stat svg {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+}
+
+.card-stat span {
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: none;
+  color: inherit;
+}
+
+.card-stat--cost {
+  color: #9ad8ff;
+  box-shadow: inset 0 0 0 1px rgba(154, 216, 255, 0.4);
+}
+
+.card-stat--damage {
+  color: #ffb47b;
+  box-shadow: inset 0 0 0 1px rgba(255, 180, 123, 0.4);
+}
+
+.card-stat--health {
+  color: #8af5be;
+  box-shadow: inset 0 0 0 1px rgba(138, 245, 190, 0.35);
+}
+
+.card .card-qty {
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.card-flags {
+  display: flex;
+  gap: 0.4rem;
+  margin-top: 0.3rem;
+}
+
+.card .tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.65rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.card .tag.limited {
+  background: rgba(255, 139, 106, 0.2);
+  border-color: rgba(255, 139, 106, 0.6);
+  color: var(--accent-strong);
+}
+
+.card .tag.missing {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(255, 255, 255, 0.3);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.card .tag.duplicate {
+  background: rgba(138, 245, 190, 0.2);
+  border-color: rgba(138, 245, 190, 0.55);
+  color: #8af5be;
+}
+
+.pack-summary {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: var(--radius-md);
+  padding: 1rem 1.2rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 0.9rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.pack-summary strong {
+  color: var(--accent-strong);
+}
+
+.reward-display .card {
+  width: 100%;
+}
+
+#trade-list li .wanted {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+@keyframes pop {
+  from {
+    transform: scale(0.86);
+    opacity: 0;
+  }
+  60% {
+    transform: scale(1.05);
+    opacity: 1;
+  }
+  to {
+    transform: scale(1);
+  }
+}
+
+.rarity-common {
+  border-color: rgba(148, 129, 199, 0.4);
+  box-shadow: inset 0 0 18px rgba(120, 94, 195, 0.28);
+}
+
+.rarity-uncommon {
+  border-color: rgba(83, 203, 198, 0.5);
+  box-shadow: inset 0 0 22px rgba(83, 203, 198, 0.35);
+}
+
+.rarity-rare {
+  border-color: rgba(94, 190, 255, 0.65);
+  box-shadow: inset 0 0 26px rgba(94, 190, 255, 0.45);
+}
+
+.rarity-epic {
+  border-color: rgba(255, 139, 245, 0.8);
+  box-shadow: inset 0 0 32px rgba(255, 139, 245, 0.55);
+}
+
+.rarity-legendary {
+  border-color: rgba(255, 207, 106, 0.9);
+  box-shadow: inset 0 0 40px rgba(255, 207, 106, 0.65);
+}
+
+.collection-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.collection-stats div {
+  background: rgba(22, 16, 41, 0.7);
+  padding: 1.5rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.stat-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.set-progress-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.set-card {
+  background: rgba(17, 12, 30, 0.9);
+  padding: 1.8rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: grid;
+  gap: 0.9rem;
+}
+
+.progress-bar {
+  position: relative;
+  height: 10px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress-bar span {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, rgba(94, 190, 255, 0.3), rgba(255, 139, 106, 0.75));
+  border-radius: inherit;
+  transition: width 400ms ease;
+}
+
+.set-card footer {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.set-card.completed {
+  border-color: rgba(255, 207, 106, 0.7);
+  box-shadow: 0 0 30px rgba(255, 207, 106, 0.25);
+}
+
+.trade-hub {
+  background: rgba(14, 10, 26, 0.85);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 1.8rem;
+}
+
+#trade-list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+#trade-list li {
+  background: rgba(255, 255, 255, 0.04);
+  padding: 0.9rem 1.1rem;
+  border-radius: 12px;
+  font-size: 0.9rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.collection-viewer {
+  margin-top: 2.5rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.collection-viewer h3 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.collection-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1rem;
+  align-items: flex-end;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 1.2rem;
+}
+
+.collection-field {
+  display: grid;
+  gap: 0.4rem;
+  flex: 1 1 160px;
+}
+
+.collection-field--search {
+  flex: 2 1 240px;
+}
+
+.collection-field label {
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.collection-input {
+  width: 100%;
+  padding: 0.65rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(12, 9, 24, 0.85);
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  letter-spacing: 0.03em;
+}
+
+.collection-input:focus {
+  outline: 2px solid rgba(94, 190, 255, 0.5);
+  outline-offset: 2px;
+}
+
+.collection-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.55rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(8, 6, 18, 0.7);
+  font-size: 0.7rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.65);
+  cursor: pointer;
+}
+
+.collection-toggle input {
+  width: 1rem;
+  height: 1rem;
+  accent-color: var(--accent-strong);
+}
+
+.collection-filter-summary {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.64);
+  letter-spacing: 0.02em;
+}
+
+.collection-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.2rem;
+}
+
+.collection-card-grid .card {
+  height: 100%;
+}
+
+.collection-empty {
+  margin: 0;
+  padding: 1.3rem 1.6rem;
+  border-radius: var(--radius-md);
+  border: 1px dashed rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.04);
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.64);
+  text-align: center;
+}
+
+@media (max-width: 640px) {
+  .collection-toggle {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+.deckbuilder {
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.deckbuilder-layout {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2rem);
+  max-width: 1080px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+@media (min-width: 960px) {
+  .deckbuilder-layout {
+    grid-template-columns: minmax(220px, 280px) 1fr;
+    align-items: start;
+  }
+}
+
+.deckbuilder-sidebar {
+  background: rgba(15, 11, 28, 0.92);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 1.25rem;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.deckbuilder-sidebar h3 {
+  margin: 0;
+  font-size: 1rem;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.deckbuilder-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.deckbuilder-input {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(11, 7, 22, 0.88);
+  color: var(--text-primary);
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+}
+
+.deckbuilder-input:focus {
+  outline: 2px solid rgba(255, 139, 106, 0.6);
+  outline-offset: 2px;
+}
+
+.deckbuilder-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.deckbuilder .primary,
+.deckbuilder .ghost {
+  font-size: 0.72rem;
+  padding: 0.6rem 1.2rem;
+  letter-spacing: 0.14em;
+}
+
+.deckbuilder-count {
+  margin: 0;
+  font-size: 0.8rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.deckbuilder-count.is-complete {
+  color: var(--accent-strong);
+}
+
+.deckbuilder-status {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.deckbuilder-status[data-tone="success"] {
+  color: rgba(146, 255, 214, 0.92);
+}
+
+.deckbuilder-status[data-tone="warn"] {
+  color: rgba(255, 196, 137, 0.95);
+}
+
+.deckbuilder-columns {
+  display: grid;
+  gap: clamp(1.25rem, 3vw, 1.75rem);
+}
+
+.deckbuilder-column {
+  background: rgba(14, 10, 28, 0.85);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 1.25rem;
+  display: grid;
+  gap: 0.85rem;
+  align-content: start;
+  width: 100%;
+  position: relative;
+}
+
+.deckbuilder-column header h3 {
+  margin: 0 0 0.35rem;
+}
+
+.deckbuilder-column header p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.deckbuilder-card-list {
+  position: relative;
+  list-style: none;
+  margin: 0;
+  padding: 0.75rem 1.5rem 1.75rem;
+  display: flex;
+  gap: clamp(1rem, 2.5vw, 1.6rem);
+  overflow-x: auto;
+  overflow-y: visible;
+  align-items: stretch;
+  scroll-snap-type: none;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+  cursor: grab;
+  user-select: none;
+  overscroll-behavior-x: contain;
+  touch-action: pan-y;
+  scroll-behavior: auto;
+}
+
+.deckbuilder-card-list::-webkit-scrollbar {
+  display: none;
+}
+
+.deckbuilder-card-list.is-dragging {
+  cursor: grabbing;
+}
+
+.deckbuilder-card-list.is-empty {
+  cursor: default;
+}
+
+.deckbuilder-card-list[data-carousel-mode] {
+  perspective: 1400px;
+  transform-style: preserve-3d;
+}
+
+.deckbuilder-card-list[data-carousel-mode="collection"] {
+  perspective: 1600px;
+}
+
+.deckbuilder-card-list[data-carousel-mode]::before,
+.deckbuilder-card-list[data-carousel-mode]::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: clamp(18px, 4vw, 48px);
+  pointer-events: none;
+  z-index: 2;
+  transition: opacity var(--transition);
+}
+
+.deckbuilder-card-list[data-carousel-mode]::before {
+  left: 0;
+  background: linear-gradient(90deg, rgba(10, 7, 22, 0.95), transparent);
+}
+
+.deckbuilder-card-list[data-carousel-mode]::after {
+  right: 0;
+  background: linear-gradient(270deg, rgba(10, 7, 22, 0.95), transparent);
+}
+
+.deckbuilder-card-list.is-empty::before,
+.deckbuilder-card-list.is-empty::after {
+  opacity: 0;
+}
+
+.deckbuilder-card-list.is-at-start::before {
+  opacity: 0;
+}
+
+.deckbuilder-card-list.is-at-end::after {
+  opacity: 0;
+}
+
+.deckbuilder-card-list > .deckbuilder-note,
+.deckbuilder-card-list > .deckbuilder-empty,
+.deckbuilder-card-list > p {
+  flex: 0 0 clamp(240px, 68vw, 320px);
+  max-width: clamp(240px, 68vw, 320px);
+  align-self: center;
+}
+
+.deckbuilder-card {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(72px, 84px) 1fr;
+  gap: 0.75rem;
+  background: rgba(10, 7, 22, calc(0.7 + 0.18 * var(--carousel-focus, 0)));
+  border: 1px solid rgba(255, 255, 255, calc(0.08 + 0.12 * var(--carousel-focus, 0)));
+  border-radius: var(--radius-md);
+  padding: 0.75rem;
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, calc(0.02 + 0.08 * var(--carousel-focus, 0))),
+    0 18px 32px rgba(8, 4, 20, calc(0.24 + 0.36 * var(--carousel-focus, 0)));
+  width: clamp(240px, 70vw, 320px);
+  flex: 0 0 clamp(240px, 70vw, 320px);
+  margin: 0;
+  --carousel-scale: 1;
+  --carousel-focus: 0;
+  --carousel-tilt: 0deg;
+  --carousel-shift: 0px;
+  --carousel-z: 1;
+  transform-origin: center bottom;
+  transform: translate3d(0, calc(var(--carousel-shift, 0px) * -1), 0)
+    rotateY(var(--carousel-tilt, 0deg))
+    scale(var(--carousel-scale, 1));
+  transition:
+    transform 0.55s cubic-bezier(0.22, 0.61, 0.36, 1),
+    box-shadow 0.55s cubic-bezier(0.22, 0.61, 0.36, 1),
+    border-color 0.55s cubic-bezier(0.22, 0.61, 0.36, 1),
+    background 0.55s cubic-bezier(0.22, 0.61, 0.36, 1);
+  z-index: var(--carousel-z, 1);
+  will-change: transform;
+}
+
+.deckbuilder-card-list[data-carousel-mode="deck"] .deckbuilder-card {
+  transform-origin: center center;
+}
+
+.deckbuilder-card--full-art {
+  grid-template-columns: 1fr;
+  gap: 0.6rem;
+  padding: 0.5rem;
+  background: transparent;
+  border: 2px solid transparent;
+  border-radius: var(--radius-md);
+  box-shadow: none;
+  width: min(100%, 320px);
+  margin-inline: auto;
+  justify-items: center;
+}
+
+.deckbuilder-card-full-art {
+  margin: 0;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  aspect-ratio: 3 / 4;
+  background: rgba(10, 7, 22, 0.92);
+  box-shadow: 0 18px 36px rgba(8, 4, 20, 0.55);
+  width: 100%;
+}
+
+.deckbuilder-card--full-art .deckbuilder-card-full-art img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: block;
+  background: rgba(7, 5, 14, 0.9);
+}
+
+.deckbuilder-card--full-art .deckbuilder-card-footer {
+  background: rgba(13, 9, 24, 0.88);
+  border-radius: 999px;
+  padding: 0.45rem 0.75rem;
+}
+
+.deckbuilder-card--full-art .deckbuilder-card-count {
+  font-size: 0.7rem;
+}
+
+.deckbuilder-card--full-art .deckbuilder-card-controls {
+  gap: 0.35rem;
+}
+
+.deckbuilder-card-art {
+  border-radius: 14px;
+  overflow: hidden;
+  aspect-ratio: 3 / 4;
+  background: rgba(255, 255, 255, 0.04);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.deckbuilder-card-art img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.deckbuilder-card-info {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.deckbuilder-card-info header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.6rem;
+}
+
+.deckbuilder-card-info strong {
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+}
+
+.deckbuilder-card-rarity {
+  font-size: 0.7rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.deckbuilder-card-type {
+  margin: 0;
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.deckbuilder-card-stats {
+  display: flex;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.deckbuilder-stat {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.deckbuilder-stat svg {
+  width: 14px;
+  height: 14px;
+}
+
+.deckbuilder-stat strong {
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  color: var(--text-primary);
+}
+
+.deckbuilder-card-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.deckbuilder-card-count {
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.deckbuilder-card-controls {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.deckbuilder-button {
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.85);
+  border-radius: 999px;
+  padding: 0.3rem 0.7rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition), border-color var(--transition), color var(--transition);
+}
+
+.deckbuilder-button:hover:not(:disabled) {
+  background: rgba(255, 139, 106, 0.22);
+  border-color: rgba(255, 139, 106, 0.65);
+  color: #fff;
+}
+
+.deckbuilder-button[data-action="remove"] {
+  border-color: rgba(255, 106, 142, 0.45);
+  color: rgba(255, 184, 200, 0.9);
+}
+
+.deckbuilder-button[data-action="remove"]:hover:not(:disabled) {
+  background: rgba(255, 106, 142, 0.2);
+  color: #fff;
+  border-color: rgba(255, 106, 142, 0.8);
+}
+
+.deckbuilder-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.deckbuilder-card.is-depleted {
+  opacity: 0.6;
+}
+
+.deckbuilder-card.is-capped {
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.deckbuilder-empty {
+  margin: 0;
+  padding: 1rem;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.05);
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.deckbuilder-note {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.05);
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.deckbuilder-note.is-warning {
+  color: rgba(255, 210, 150, 0.95);
+}
+
+.deckbuilder-note.is-success {
+  color: rgba(148, 255, 210, 0.92);
+  background: rgba(26, 64, 44, 0.6);
+}
+
+.events .event-card {
+  background: radial-gradient(circle at top, rgba(255, 139, 106, 0.25), transparent 70%),
+    rgba(19, 12, 36, 0.92);
+  padding: 2.5rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(255, 139, 106, 0.3);
+  display: grid;
+  gap: 1.2rem;
+}
+
+.event-details {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1.2rem;
+}
+
+.multiplayer {
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.multiplayer .arena-grid {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.multiplayer .duel-overview {
+  background: rgba(15, 11, 28, 0.9);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 1.5rem;
+  display: grid;
+  gap: 1.2rem;
+}
+
+.multiplayer .duel-meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.2rem;
+}
+
+.multiplayer .duel-meta strong {
+  font-size: 1.5rem;
+  color: var(--accent-strong);
+}
+
+.multiplayer .duel-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.multiplayer .duel-hint {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.duel-decklist {
+  background: rgba(10, 7, 22, 0.8);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 1rem 1.25rem;
+  color: rgba(255, 255, 255, 0.8);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.duel-decklist[open] {
+  box-shadow: 0 14px 32px rgba(10, 22, 44, 0.35);
+}
+
+.duel-decklist summary {
+  cursor: pointer;
+  font-size: 0.8rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.7);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.duel-decklist summary::-webkit-details-marker {
+  display: none;
+}
+
+.duel-decklist-body {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.duel-decklist.is-empty summary {
+  cursor: default;
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.duel-decklist-section {
+  background: rgba(18, 14, 34, 0.85);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  padding: 0.9rem 1rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.duel-decklist-section h4 {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.duel-decklist-label {
+  margin: 0;
+  font-size: 0.7rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.duel-decklist-summary {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.duel-decklist-items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.duel-decklist-entry {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.35rem 0.75rem;
+  align-items: center;
+  padding: 0.55rem 0.75rem;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.duel-decklist-count {
+  grid-row: span 2;
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--accent-strong);
+  background: rgba(111, 242, 255, 0.12);
+  border-radius: 999px;
+  padding: 0.2rem 0.6rem;
+}
+
+.duel-decklist-name {
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.88);
+}
+
+.duel-decklist-meta {
+  grid-column: 2;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.duel-decklist-empty {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.duel-target-panel {
+  display: grid;
+  gap: 0.9rem;
+  margin-top: 1.5rem;
+  padding: 1.25rem;
+  border-radius: var(--radius-md);
+  border: 1px dashed rgba(111, 242, 255, 0.25);
+  background: rgba(9, 13, 28, 0.8);
+  transition: border-color var(--transition), box-shadow var(--transition), opacity var(--transition);
+}
+
+.duel-target-panel.is-visible {
+  border-color: rgba(111, 242, 255, 0.45);
+  box-shadow: 0 16px 36px rgba(32, 94, 150, 0.28);
+}
+
+.duel-target-panel:not(.is-visible) {
+  opacity: 0.7;
+}
+
+.duel-target-message {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(111, 242, 255, 0.9);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.duel-target-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.duel-target-option {
+  padding: 0.6rem 0.9rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(111, 242, 255, 0.4);
+  background: rgba(13, 18, 36, 0.92);
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: transform var(--transition), border-color var(--transition), box-shadow var(--transition);
+}
+
+.duel-target-option:hover {
+  transform: translateY(-2px);
+  border-color: rgba(111, 242, 255, 0.65);
+  box-shadow: 0 12px 24px rgba(59, 177, 255, 0.25);
+}
+
+.duel-target-cancel {
+  justify-self: start;
+  padding: 0.55rem 1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: transparent;
+  color: rgba(255, 255, 255, 0.65);
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: color var(--transition), border-color var(--transition), transform var(--transition);
+}
+
+.duel-target-cancel:hover {
+  color: rgba(255, 255, 255, 0.85);
+  border-color: rgba(255, 255, 255, 0.35);
+  transform: translateY(-1px);
+}
+
+.duel-target-cancel:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.duel-boards {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.duel-player {
+  position: relative;
+  background: rgba(15, 11, 30, 0.88);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 1.5rem;
+  display: grid;
+  gap: 1.1rem;
+  transition: border-color var(--transition), box-shadow var(--transition), transform var(--transition);
+}
+
+.duel-player.is-active {
+  border-color: rgba(111, 242, 255, 0.6);
+  box-shadow: 0 0 0 1px rgba(111, 242, 255, 0.25), 0 20px 40px rgba(15, 40, 64, 0.45);
+  transform: translateY(-4px);
+}
+
+.duel-player.is-winner {
+  border-color: rgba(255, 207, 106, 0.65);
+  box-shadow: 0 0 0 1px rgba(255, 207, 106, 0.35), 0 28px 50px rgba(255, 207, 106, 0.3);
+}
+
+.duel-player.is-defeated {
+  opacity: 0.55;
+}
+
+.duel-player-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.duel-player-name {
+  font-family: "Press Start 2P", cursive;
+  font-size: 0.8rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.duel-player-status {
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.duel-player.is-active .duel-player-status {
+  color: #6ff2ff;
+}
+
+.duel-player.is-winner .duel-player-status {
+  color: var(--accent-strong);
+}
+
+.duel-hero {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  width: 100%;
+  margin: 0.75rem 0 1.25rem;
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(18, 16, 32, 0.85);
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  transition: border-color var(--transition), box-shadow var(--transition), transform var(--transition), color var(--transition);
+}
+
+.duel-hero:disabled {
+  cursor: default;
+  opacity: 1;
+}
+
+.duel-hero.is-targetable {
+  border-color: rgba(111, 242, 255, 0.55);
+  box-shadow: 0 0 0 2px rgba(111, 242, 255, 0.24);
+  color: rgba(111, 242, 255, 0.95);
+  cursor: pointer;
+}
+
+.duel-hero.is-targetable:hover {
+  transform: translateY(-2px);
+}
+
+.duel-hero-label {
+  font-weight: 600;
+  letter-spacing: 0.22em;
+}
+
+.duel-hero-health {
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+}
+
+.duel-hero-health strong {
+  font-size: 1.4rem;
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.duel-hero-health small {
+  font-size: 0.7rem;
+  letter-spacing: 0.2em;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.duel-player-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+}
+
+.duel-player-stats strong {
+  font-size: 1.3rem;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.duel-crystals {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  min-height: 28px;
+}
+
+.duel-board {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.duel-board-empty {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.55);
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: var(--radius-md);
+  padding: 0.75rem 1rem;
+  border: 1px dashed rgba(255, 255, 255, 0.08);
+}
+
+.duel-board-card {
+  background: rgba(21, 18, 37, 0.9);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 0.75rem 1rem;
+  display: grid;
+  gap: 0.6rem;
+  box-shadow: 0 14px 28px rgba(9, 12, 28, 0.3);
+  transition: border-color var(--transition), box-shadow var(--transition), transform var(--transition);
+}
+
+.duel-board-card.is-exhausted {
+  opacity: 0.75;
+}
+
+.duel-board-card.is-bulwark {
+  border-color: rgba(255, 199, 102, 0.4);
+  box-shadow: 0 16px 34px rgba(255, 183, 76, 0.35);
+}
+
+.duel-board-card.is-selectable {
+  cursor: pointer;
+  border-color: rgba(111, 242, 255, 0.4);
+}
+
+.duel-board-card.is-selectable:hover {
+  transform: translateY(-2px);
+  border-color: rgba(111, 242, 255, 0.65);
+}
+
+.duel-board-card.is-targetable {
+  cursor: pointer;
+  border-color: rgba(255, 120, 196, 0.5);
+  box-shadow: 0 0 0 2px rgba(255, 120, 196, 0.22);
+}
+
+.duel-board-card.is-targetable:hover {
+  transform: translateY(-2px);
+}
+
+.duel-board-card.is-selected {
+  border-color: rgba(111, 242, 255, 0.85);
+  box-shadow: 0 18px 40px rgba(111, 242, 255, 0.25);
+}
+
+.duel-board-card-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.duel-board-card-header strong {
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.duel-board-card-stats {
+  display: flex;
+  gap: 1.5rem;
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.duel-board-card-stats span {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.duel-board-card-stats strong {
+  font-size: 1.1rem;
+  color: rgba(255, 255, 255, 0.92);
+  letter-spacing: normal;
+  text-transform: none;
+}
+
+.duel-tag {
+  font-size: 0.65rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: #ffd66b;
+  background: rgba(255, 198, 102, 0.18);
+  border-radius: 999px;
+  padding: 0.15rem 0.55rem;
+}
+
+.duel-crystal {
+  width: 18px;
+  height: 24px;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  opacity: 0.25;
+  clip-path: polygon(50% 0%, 82% 18%, 100% 58%, 50% 100%, 0% 58%, 18% 18%);
+  transition: opacity var(--transition), transform var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+.duel-crystal.is-active {
+  opacity: 0.6;
+}
+
+.duel-crystal.is-filled {
+  opacity: 1;
+  background: linear-gradient(180deg, #6ff2ff, #438bff);
+  box-shadow: 0 8px 18px rgba(79, 180, 255, 0.35);
+  transform: translateY(-2px);
+}
+
+.duel-hand {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.duel-hand-empty {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.55);
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: var(--radius-md);
+  padding: 0.75rem 1rem;
+  border: 1px dashed rgba(255, 255, 255, 0.08);
+}
+
+.duel-card {
+  display: grid;
+  grid-template-columns: 52px 1fr;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 0.75rem 1rem;
+  background: rgba(18, 14, 34, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-md);
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: transform var(--transition), border-color var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+.duel-card-body {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.duel-card:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  box-shadow: none;
+}
+
+.duel-card.is-playable {
+  border-color: rgba(111, 242, 255, 0.4);
+  box-shadow: 0 14px 30px rgba(58, 164, 255, 0.3);
+  background: rgba(18, 27, 48, 0.95);
+}
+
+.duel-card.is-playable:not(:disabled):hover {
+  transform: translateY(-3px);
+}
+
+.duel-card.is-selected {
+  border-color: rgba(111, 242, 255, 0.8);
+  box-shadow: 0 0 0 2px rgba(111, 242, 255, 0.3);
+  transform: translateY(-2px);
+}
+
+.duel-card-cost {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #6ff2ff, #438bff);
+  font-weight: 700;
+  font-size: 1.25rem;
+  color: #09142f;
+  box-shadow: 0 10px 24px rgba(54, 153, 255, 0.35);
+}
+
+.duel-card-body strong {
+  display: block;
+  font-size: 1rem;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.duel-card-meta {
+  display: block;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.duel-card-text {
+  font-size: 0.75rem;
+  line-height: 1.4;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.duel-card.is-spell .duel-card-cost {
+  background: linear-gradient(180deg, #f472b6, #a855f7);
+  color: #260d3d;
+  box-shadow: 0 12px 26px rgba(209, 89, 186, 0.35);
+}
+
+.duel-log-wrapper {
+  position: relative;
+  z-index: 1;
+  background: rgba(12, 9, 24, 0.85);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 1.5rem;
+}
+
+.duel-log {
+  list-style: none;
+  margin: 1rem 0 0;
+  padding: 0;
+  max-height: 280px;
+  overflow-y: auto;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.duel-log li {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 12px;
+  padding: 0.65rem 0.9rem;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.68);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.duel-log li strong {
+  color: var(--accent-strong);
+}
+
+.duel-log-empty {
+  font-style: italic;
+  opacity: 0.7;
+}
+
+@media (min-width: 720px) {
+  .duel-boards {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 960px) {
+  .multiplayer .arena-grid {
+    grid-template-columns: minmax(220px, 320px) 1fr;
+  }
+}
+
+.roadmap-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.roadmap-grid article {
+  background: rgba(18, 12, 32, 0.85);
+  padding: 1.5rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  min-height: 180px;
+}
+
+.footer {
+  text-align: center;
+  padding: 3rem 1rem;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.85rem;
+}
+
+.placeholder {
+  text-align: center;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+@media (max-width: 720px) {
+  .top-bar {
+    flex-direction: column;
+    gap: 0.8rem;
+  }
+
+  .nav-links {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  button {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .hero {
+    padding-top: 2rem;
+  }
+
+  .multiplayer .arena-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .duel-player {
+    padding: 1.2rem;
+  }
+
+  .duel-player-stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+  }
+
+  .duel-card {
+    grid-template-columns: 42px 1fr;
+    gap: 0.6rem;
+  }
+
+  .duel-card-cost {
+    width: 42px;
+    height: 42px;
+    font-size: 1.05rem;
+  }
+}


### PR DESCRIPTION
## Summary
- lower the panel viewport height and header spacing so arena, deck workshop, and bonus tabs no longer stretch far past their content, and anchor grid-based sections so their content starts right under the headings
- tighten the full-art card components so the three illustrated cards stay centered within their frames in collection and deck views
- remove the vertical lift from the deckbuilder carousel to keep swipe animations smooth without pulling cards out of bounds

## Testing
- node --check main.js

------
https://chatgpt.com/codex/tasks/task_e_68ccace8abdc8327a38da8c052d71d10